### PR TITLE
Fix Docker: Node 20 + @swc/helpers for standalone

### DIFF
--- a/Dockerfile.all-in-one
+++ b/Dockerfile.all-in-one
@@ -33,8 +33,8 @@ COPY --from=mcr.microsoft.com/dotnet/aspnet:8.0-alpine /usr/share/dotnet /usr/sh
 ENV PATH="/usr/share/dotnet:${PATH}" \
     DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
-# Install Node.js
-RUN apk add --no-cache nodejs
+# Use Node 20 (Alpine apk has Node 24 which breaks Next.js standalone + @swc/helpers)
+COPY --from=node:20-alpine /usr/local /usr/local
 
 # Copy API
 COPY --from=api-build /app/publish /app/api

--- a/portal/next.config.ts
+++ b/portal/next.config.ts
@@ -5,6 +5,11 @@ const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  experimental: {
+    outputFileTracingIncludes: {
+      "/*": ["./node_modules/@swc/helpers/**/*"],
+    },
+  },
 };
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
Fixes MODULE_NOT_FOUND for @swc/helpers in Docker:
- Use Node 20 from node:20-alpine (Alpine apk has Node 24)
- Add outputFileTracingIncludes for @swc/helpers in next.config

Made with [Cursor](https://cursor.com)