### PR TITLE
Fix Docker: force Node 20, copy @swc/helpers

### DIFF
--- a/Dockerfile.all-in-one
+++ b/Dockerfile.all-in-one
@@ -35,6 +35,10 @@ ENV PATH="/usr/share/dotnet:${PATH}" \
 
 # Use Node 20 (Alpine apk has Node 24 which breaks Next.js standalone + @swc/helpers)
 COPY --from=node:20-alpine /usr/local /usr/local
+ENV PATH="/usr/local/bin:${PATH}"
+
+# Remove Alpine's Node 24 if present (so /usr/local/bin/node wins)
+RUN rm -f /usr/bin/node /usr/bin/npm 2>/dev/null || true
 
 # Copy API
 COPY --from=api-build /app/publish /app/api
@@ -43,6 +47,8 @@ COPY --from=api-build /app/publish /app/api
 COPY --from=portal-build /app/.next/standalone /app/portal
 COPY --from=portal-build /app/.next/static /app/portal/.next/static
 COPY --from=portal-build /app/public /app/portal/public
+# Ensure @swc/helpers is present (standalone tracing can miss it)
+COPY --from=portal-build /app/node_modules/@swc /app/portal/node_modules/@swc
 
 # Startup script (fix CRLF if from Windows)
 COPY docker/start-all-in-one.sh /start.sh

--- a/docker/start-all-in-one.sh
+++ b/docker/start-all-in-one.sh
@@ -27,4 +27,4 @@ sleep 5
 cd /app/portal
 export NODE_ENV=production
 export PORT=3000
-exec node server.js
+exec /usr/local/bin/node server.js


### PR DESCRIPTION
Fixes MODULE_NOT_FOUND in container:
- PATH + remove Alpine Node 24
- Explicit /usr/local/bin/node in startup
- Copy @swc/helpers from build to standalone

Made with [Cursor](https://cursor.com)