### PR TITLE
Fix Docker: full build with node_modules

### DIFF
--- a/Dockerfile.all-in-one
+++ b/Dockerfile.all-in-one
@@ -43,12 +43,12 @@ RUN rm -f /usr/bin/node /usr/bin/npm 2>/dev/null || true
 # Copy API
 COPY --from=api-build /app/publish /app/api
 
-# Copy Portal (standalone)
-COPY --from=portal-build /app/.next/standalone /app/portal
-COPY --from=portal-build /app/.next/static /app/portal/.next/static
+# Copy Portal (full build with complete node_modules - avoids standalone tracing issues)
+COPY --from=portal-build /app/.next /app/portal/.next
 COPY --from=portal-build /app/public /app/portal/public
-# Ensure @swc/helpers is present (standalone tracing can miss it)
-COPY --from=portal-build /app/node_modules/@swc /app/portal/node_modules/@swc
+COPY --from=portal-build /app/node_modules /app/portal/node_modules
+COPY --from=portal-build /app/package.json /app/portal/package.json
+COPY --from=portal-build /app/next.config.ts /app/portal/next.config.ts
 
 # Startup script (fix CRLF if from Windows)
 COPY docker/start-all-in-one.sh /start.sh

--- a/docker/start-all-in-one.sh
+++ b/docker/start-all-in-one.sh
@@ -27,4 +27,4 @@ sleep 5
 cd /app/portal
 export NODE_ENV=production
 export PORT=3000
-exec /usr/local/bin/node server.js
+exec npm run start

--- a/portal/next.config.ts
+++ b/portal/next.config.ts
@@ -3,13 +3,6 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
-const nextConfig: NextConfig = {
-  output: "standalone",
-  experimental: {
-    outputFileTracingIncludes: {
-      "/*": ["./node_modules/@swc/helpers/**/*"],
-    },
-  },
-};
+const nextConfig: NextConfig = {};
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
Use full build instead of standalone to fix @swc/helpers MODULE_NOT_FOUND

Made with [Cursor](https://cursor.com)