### PR TITLE
fix(ngrok): web_addr, wait for tunnels, CI diagnostics

### DIFF
--- a/.github/workflows/push-docker-mac.yml
+++ b/.github/workflows/push-docker-mac.yml
@@ -120,9 +120,22 @@ jobs:
             echo "::notice::NGROK_AUTHTOKEN not set — in-container ngrok is disabled. Add repo secret to enable public URLs."
             exit 0
           fi
-          echo "Waiting for in-container ngrok API on localhost:4040..."
-          sleep 15
-          TUNNELS=$(curl -fsS --retry 10 --retry-delay 3 "http://127.0.0.1:4040/api/tunnels" 2>/dev/null || echo "{}")
+
+          echo "Waiting for ngrok tunnels (polls localhost:4040, up to ~2 min)..."
+          TUNNELS=$(python3 scripts/wait-ngrok-tunnels.py)
+          TUNNEL_COUNT=$(echo "$TUNNELS" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('tunnels') or []))" 2>/dev/null || echo 0)
+
+          if [ "$TUNNEL_COUNT" = "0" ]; then
+            echo "::warning::No ngrok tunnels yet. Diagnostics:"
+            echo "--- curl :4040 (raw) ---"
+            curl -sv "http://127.0.0.1:4040/api/tunnels" 2>&1 | tail -30 || true
+            echo "--- docker ps (cargohub) ---"
+            docker ps -a --filter name=cargohub --no-trunc 2>/dev/null || true
+            echo "--- docker logs cargohub (last 80 lines) ---"
+            docker logs cargohub 2>&1 | tail -80 || true
+            echo "--- /tmp/ngrok.log inside container ---"
+            docker exec cargohub tail -60 /tmp/ngrok.log 2>/dev/null || echo "(no log or container not running)"
+          fi
 
           echo ""
           echo "=========================================="

--- a/RUN.md
+++ b/RUN.md
@@ -13,7 +13,7 @@ docker pull maleesha404/cargohub:latest
 docker run -d -p 3000:3000 -p 8080:8080 -p 4040:4040 -v cargohub_data:/var/lib/postgresql/data --name cargohub maleesha404/cargohub:latest
 ```
 
-**Public URLs (ngrok inside the image):** set `-e NGROK_AUTHTOKEN=your_token` on `docker run` (or use `docker-compose.one.yml`). The image includes the ngrok agent; tunnels start automatically. Then open **http://localhost:4040** on the host for the ngrok dashboard and JSON with **`public_url`** for portal (3000) and API (8080). You do **not** need ngrok installed on the host.
+**Public URLs (ngrok inside the image):** set `-e NGROK_AUTHTOKEN=your_token` on `docker run` (or use `docker-compose.one.yml`). The image includes the ngrok agent; tunnels start automatically. **`ngrok.yml` uses `web_addr: 0.0.0.0:4040`** so the host can reach the ngrok API on **http://localhost:4040**. You do **not** need ngrok installed on the host. If URLs are empty in CI, **pull the latest image** (older images may not include in-container ngrok).
 
 Or with compose:
 

--- a/docker/start-all-in-one.sh
+++ b/docker/start-all-in-one.sh
@@ -43,10 +43,24 @@ if [ -n "$NGROK_AUTHTOKEN" ]; then
   echo "Starting ngrok (in-container)..."
   ngrok config add-authtoken "$NGROK_AUTHTOKEN" 2>/dev/null || true
   ngrok start --all --config /etc/ngrok/ngrok.yml >> /tmp/ngrok.log 2>&1 &
-  sleep 3
-  echo "ngrok tunnel status:"
-  curl -sS "http://127.0.0.1:4040/api/tunnels" 2>/dev/null | head -c 4000 || echo "(ngrok API not ready yet — check /tmp/ngrok.log)"
-  echo ""
+  # Wait until API responds (tunnels may take a few more seconds)
+  i=0
+  while [ "$i" -lt 60 ]; do
+    if curl -fsS "http://127.0.0.1:4040/api/tunnels" >/dev/null 2>&1; then
+      echo "ngrok API is up."
+      break
+    fi
+    i=$((i + 1))
+    sleep 1
+  done
+  if [ "$i" -ge 60 ]; then
+    echo "ngrok API did not become ready. Last 50 lines of /tmp/ngrok.log:"
+    tail -50 /tmp/ngrok.log 2>/dev/null || true
+  else
+    echo "ngrok tunnel status:"
+    curl -sS "http://127.0.0.1:4040/api/tunnels" 2>/dev/null | head -c 4000 || true
+    echo ""
+  fi
 fi
 
 # Start Portal (foreground - keeps container alive)

--- a/ngrok.yml
+++ b/ngrok.yml
@@ -1,8 +1,9 @@
 # Used by GitHub Actions on your self-hosted Mac to expose portal (3000) + API (8080).
 # Auth token comes from repo secret NGROK_AUTHTOKEN (not stored in this file).
 # https://ngrok.com/docs/agent/config/v2/
-
+# Bind web UI / API on all interfaces so host can reach :4040 via docker -p 4040:4040
 version: "2"
+web_addr: 0.0.0.0:4040
 tunnels:
   portal:
     proto: http

--- a/scripts/show-ngrok-public-urls.py
+++ b/scripts/show-ngrok-public-urls.py
@@ -34,7 +34,14 @@ def main():
         print(f"::notice title=Public URL — {label}::{safe}", file=sys.stderr)
 
     if not rows:
-        print("  (no tunnels in response — is ngrok running inside the container?)")
+        print("  (no tunnels in response)")
+        print("")
+        print("  Troubleshooting:")
+        print("  - Image must include ngrok (Dockerfile.all-in-one) — pull latest :latest")
+        print("  - NGROK_AUTHTOKEN must be passed into the container (compose env / GitHub secret)")
+        print("  - ngrok.yml uses web_addr: 0.0.0.0:4040 so the host can reach the API")
+        print("  - Check: docker logs cargohub 2>&1 | tail -80")
+        print("  - Check: docker exec cargohub tail -50 /tmp/ngrok.log")
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_path and rows:

--- a/scripts/wait-ngrok-tunnels.py
+++ b/scripts/wait-ngrok-tunnels.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Poll ngrok /api/tunnels until at least one tunnel exists or timeout. Prints final JSON to stdout."""
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+URL = "http://127.0.0.1:4040/api/tunnels"
+# Total wait up to ~2 minutes (60 * 2s)
+ATTEMPTS = 60
+INTERVAL = 2.0
+
+
+def main():
+    last_body = "{}"
+    for attempt in range(ATTEMPTS):
+        try:
+            with urllib.request.urlopen(URL, timeout=5) as resp:
+                last_body = resp.read().decode("utf-8", errors="replace")
+            data = json.loads(last_body)
+            tunnels = data.get("tunnels") or []
+            if len(tunnels) > 0:
+                print(last_body)
+                return
+        except (urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, TimeoutError):
+            pass
+        except Exception:
+            pass
+        if attempt < ATTEMPTS - 1:
+            time.sleep(INTERVAL)
+
+    print(last_body)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Follow-up to #35: **web_addr 0.0.0.0:4040**, startup wait, **wait-ngrok-tunnels.py**, workflow diagnostics.

Made with [Cursor](https://cursor.com)