### PR TITLE
feat(docker): nginx :8888, single ngrok tunnel, same-origin API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,13 +14,16 @@ Jwt__Issuer=PortalIssuer
 Jwt__Audience=PortalAudience
 
 # ---- Portal (build-time, for Vercel/Next.js) ----
+# Local dev: API port (Launcher often 5299; Docker API is 8080)
 NEXT_PUBLIC_API_URL=http://localhost:5299
+# Dockerfile.all-in-one bakes __SAME_ORIGIN__ — browser calls API on same host as the UI (nginx :8888 + ngrok)
 
 # ---- CORS (portal URL for API) ----
 Cors__PortalOrigin=http://localhost:3000
-# Self-hosted Docker (docker-compose.one / ~/.cargohub.env on runner): compose uses this host var name
-# CORS__PORTAL_ORIGIN=https://your-portal.ngrok-free.app
-# GitHub Actions / docker-compose.one: NGROK_AUTHTOKEN in repo Secrets or .env — ngrok agent runs *inside* the all-in-one image
+# Remote demo (ngrok → nginx :8888): set to the SAME HTTPS origin the browser uses, e.g.
+# CORS__PORTAL_ORIGIN=https://your-subdomain.ngrok-free.app
+# Self-hosted Docker: ~/.cargohub.env or GitHub Secrets — compose maps CORS__PORTAL_ORIGIN → Cors__PortalOrigin
+# GitHub Actions / docker-compose.one: NGROK_AUTHTOKEN — ngrok agent runs *inside* the all-in-one image (tunnel to :8888)
 # NGROK_AUTHTOKEN=your_token_here
 # For multiple origins use indexed keys:
 # Cors__PortalOrigins__0=http://localhost:3000

--- a/.github/workflows/push-docker-mac.yml
+++ b/.github/workflows/push-docker-mac.yml
@@ -83,11 +83,11 @@ jobs:
             COMPOSE="$COMPOSE --env-file $HOME/.cargohub.env"
           fi
 
-          echo "Stopping existing stack and freeing ports 3000 / 8080..."
+          echo "Stopping existing stack and freeing ports..."
           $COMPOSE down --remove-orphans 2>/dev/null || true
           docker rm -f cargohub 2>/dev/null || true
           # Remove any container still bound to host ports (stale manual runs, duplicate stacks)
-          for port in 8080 3000 4040; do
+          for port in 8888 8080 3000 4040; do
             for id in $(docker ps -q --filter "publish=$port" 2>/dev/null); do
               echo "Removing container $id (was using port $port)"
               docker rm -f "$id" || true
@@ -100,16 +100,21 @@ jobs:
       - name: Prune old images (optional)
         run: docker image prune -f || true
 
-      - name: Smoke test (API + portal on localhost)
+      - name: Smoke test (API + portal + nginx :8888)
         run: |
           set -e
-          echo "Waiting for Postgres, API, and Next.js..."
-          sleep 20
-          curl -sfS --retry 20 --retry-delay 5 --retry-all-errors \
+          echo "Waiting for Postgres, API, Next.js, nginx..."
+          sleep 25
+          curl -sfS --retry 25 --retry-delay 5 --retry-all-errors \
             "http://localhost:8080/api/v1/health_"
-          curl -sfS --retry 20 --retry-delay 5 --retry-all-errors \
+          curl -sfS --retry 25 --retry-delay 5 --retry-all-errors \
             -o /dev/null "http://localhost:3000/"
-          echo "Smoke tests passed."
+          # Same as internet users: nginx :8888 -> /api + Next
+          curl -sfS --retry 25 --retry-delay 5 --retry-all-errors \
+            "http://localhost:8888/api/v1/health_"
+          curl -sfS --retry 25 --retry-delay 5 --retry-all-errors \
+            -o /dev/null "http://localhost:8888/en/"
+          echo "Smoke tests passed (direct :3000/:8080 and public :8888)."
 
       - name: Show public URLs (ngrok)
         continue-on-error: true

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ packages/
 .env.local
 .env.*.local
 
+# Python (CI helper scripts)
+**/__pycache__/
+*.py[cod]
+
 # Misc
 *.log
 *.tmp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,15 @@ npm run dev      # In portal/ directory for UI
 - `CargoHub.Launcher` - Runs both API and Portal (Development only)
 - `CargoHub.Api` - Runs API only (use for API-only debugging)
 
+### Docker all-in-one + ngrok (remote demo)
+
+- **Image:** `Dockerfile.all-in-one` — PostgreSQL + API + Next.js + **nginx** on **`:8888`** (single public entry: UI + `/api`).
+- **ngrok:** `ngrok.yml` tunnels **one** address — **`:8888`** (not separate 3000/8080). Dashboard on host **`:4040`**.
+- **Portal API URL:** Production image builds with `NEXT_PUBLIC_API_URL=__SAME_ORIGIN__`; `portal/src/lib/api.ts` uses `window.location.origin` in the browser so API calls match the ngrok URL.
+- **CORS:** Set `Cors__PortalOrigin` / `CORS__PORTAL_ORIGIN` to the **HTTPS ngrok origin** (same as the public URL) when testing from the internet.
+- **Routes:** Portal uses locale prefixes — e.g. **`/en/login`**, **`/en/dashboard`** — not bare `/dashboard`.
+- **Docs:** See [RUN.md](RUN.md) and `docker-compose.one.yml`.
+
 ## Testing
 
 - xUnit with Moq and NSubstitute
@@ -147,12 +156,14 @@ npm run dev      # In portal/ directory for UI
 
 **Environment Variables / Secrets:**
 - `ASPNETCORE_ENVIRONMENT` - Development/Production
-- `NEXT_PUBLIC_API_URL` - Portal API URL (portal/.env.local)
+- `NEXT_PUBLIC_API_URL` - Portal API URL (portal/.env.local); Docker all-in-one build uses `__SAME_ORIGIN__` (see `api.ts`)
+- `Cors:PortalOrigin` / `CORS__PORTAL_ORIGIN` - Must match the browser origin (e.g. ngrok HTTPS URL) for remote demos
 - Secrets live in `.env` (copy from `.env.example`). See [SECRETS.md](SECRETS.md) for GitHub Secrets.
 
 ## Important Notes
 
 - **Port 5433** is used for PostgreSQL to avoid conflicts with local PostgreSQL on 5432
+- **Docker public port 8888** — nginx fronts Next (`:3000`) and API (`:8080`); use this for a single ngrok URL
 - **build.ps1** stops running processes before building to avoid "file is locked" errors
 - Portal auto-starts from API in Development mode if found at solution root
 - Docker Desktop must be running for local database

--- a/Dockerfile.all-in-one
+++ b/Dockerfile.all-in-one
@@ -1,5 +1,5 @@
 # All-in-one: PostgreSQL + API + Portal in a single image
-# Run: docker run -p 3000:3000 -p 8080:8080 -v cargohub_data:/var/lib/postgresql/data maleesha404/cargohub:latest
+# Run (include 8888 for nginx = one public URL with ngrok): docker run -p 8888:8888 -p 3000:3000 -p 8080:8080 -p 4040:4040 -v cargohub_data:/var/lib/postgresql/data maleesha404/cargohub:latest
 
 # ---- Build API ----
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS api-build
@@ -16,7 +16,8 @@ RUN dotnet publish CargoHub.Api/CargoHub.Api.csproj -c Release -o /app/publish -
 # ---- Build Portal ----
 FROM node:20-alpine AS portal-build
 WORKDIR /app
-ENV NEXT_PUBLIC_API_URL=http://localhost:8080
+# Same-origin API via nginx + single ngrok URL (browser uses window.location.origin)
+ENV NEXT_PUBLIC_API_URL=__SAME_ORIGIN__
 COPY portal/package.json portal/package-lock.json* ./
 RUN npm ci
 COPY portal/ .
@@ -50,6 +51,11 @@ RUN apk add --no-cache curl ca-certificates \
 # Tunnel definitions (authtoken via env at runtime)
 COPY ngrok.yml /etc/ngrok/ngrok.yml
 
+# nginx: single public port 8888 -> Next :3000 + ASP.NET :8080 (/api)
+RUN apk add --no-cache nginx \
+  && rm -f /etc/nginx/http.d/default.conf
+COPY docker/nginx-public.conf /etc/nginx/http.d/cargohub.conf
+
 # Copy API
 COPY --from=api-build /app/publish /app/api
 
@@ -71,6 +77,6 @@ ENV ASPNETCORE_ENVIRONMENT=Production \
     Bootstrap__Secret="SuperAdminBootstrapSecret" \
     Jwt__SigningKey="DemoJwtKey-ChangeMe-AtLeast32Chars"
 
-# 4040 = ngrok local API / web UI (when ngrok is enabled)
-EXPOSE 3000 8080 4040
+# 8888 = nginx (use this for ngrok). 4040 = ngrok local API. 3000/8080 = direct debug.
+EXPOSE 3000 8080 4040 8888
 ENTRYPOINT ["/start.sh"]

--- a/RUN.md
+++ b/RUN.md
@@ -10,10 +10,15 @@ Single image with db + API + portal:
 
 ```bash
 docker pull maleesha404/cargohub:latest
-docker run -d -p 3000:3000 -p 8080:8080 -p 4040:4040 -v cargohub_data:/var/lib/postgresql/data --name cargohub maleesha404/cargohub:latest
+docker run -d -p 8888:8888 -p 3000:3000 -p 8080:8080 -p 4040:4040 -v cargohub_data:/var/lib/postgresql/data --name cargohub maleesha404/cargohub:latest
 ```
 
-**Public URLs (ngrok inside the image):** set `-e NGROK_AUTHTOKEN=your_token` on `docker run` (or use `docker-compose.one.yml`). The image includes the ngrok agent; tunnels start automatically. **`ngrok.yml` uses `web_addr: 0.0.0.0:4040`** so the host can reach the ngrok API on **http://localhost:4040**. You do **not** need ngrok installed on the host. If URLs are empty in CI, **pull the latest image** (older images may not include in-container ngrok).
+- **`:8888`** — **nginx**: same origin for UI + API (what you should expose behind **one** ngrok tunnel). Example: `https://<subdomain>.ngrok-free.app/en/` and API at `.../api/v1/...`.
+- **`:3000` / `:8080`** — direct Next.js / API (debug or local-only).
+
+**Public URLs (ngrok inside the image):** set `-e NGROK_AUTHTOKEN=your_token` on `docker run` (or use `docker-compose.one.yml`). The image includes the ngrok agent; tunnels start automatically. **`ngrok.yml` tunnels port `8888` (nginx)** so one HTTPS URL serves the portal and `/api`. **`ngrok.yml` uses `web_addr: 0.0.0.0:4040`** so the host can reach the ngrok API on **http://localhost:4040**. You do **not** need ngrok installed on the host. If URLs are empty in CI, **pull the latest image** (older images may not include in-container ngrok).
+
+**Paths:** The portal uses **locale-prefixed routes** (e.g. **`/en/login`**, **`/en/dashboard`**). **`/dashboard` alone returns 404** — use **`/en/dashboard`** (or your default locale).
 
 Or with compose:
 
@@ -21,8 +26,9 @@ Or with compose:
 docker compose -f docker-compose.one.yml up -d
 ```
 
-- **Portal:** http://localhost:3000  
-- **API:** http://localhost:8080  
+- **Public (nginx, same as ngrok):** http://localhost:8888  
+- **Portal (direct):** http://localhost:3000  
+- **API (direct):** http://localhost:8080  
 - **ngrok dashboard (if token set):** http://localhost:4040  
 
 ---
@@ -89,7 +95,7 @@ PostgreSQL data is stored in a Docker volume. Use `docker compose down -v` to re
 
 **Secrets:** `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` (required). Optional: `NGROK_AUTHTOKEN`, `CORS__PORTAL_ORIGIN`, `BOOTSTRAP__SECRET`, `JWT__SIGNING_KEY`.
 
-**Manual run:** Actions → **Docker Hub + Mac deploy + ngrok** → **Run workflow**. The step **Show public URLs (ngrok)** prints **Portal** and **API** links in the job log, adds **GitHub Actions notices** (hover the run), and writes a **markdown table** to the job **Summary** tab.
+**Manual run:** Actions → **Docker Hub + Mac deploy + ngrok** → **Run workflow**. The step **Show public URLs (ngrok)** prints the **public** tunnel URL (nginx `:8888`) in the job log, adds **GitHub Actions notices** (hover the run), and writes a **markdown table** to the job **Summary** tab.
 
 ### Other workflows
 
@@ -114,19 +120,20 @@ PostgreSQL data is stored in a Docker volume. Use `docker compose down -v` to re
 
 5. **Local env (optional):** `~/.cargohub.env` on the Mac for extra compose vars.
 
-6. **`CORS__PORTAL_ORIGIN`:** Set to your **portal** HTTPS ngrok URL when testing from the internet. The baked-in `NEXT_PUBLIC_API_URL` may still point at `localhost:8080` for API calls from the browser in some setups — use the **API** tunnel URL or a custom build if needed.
+6. **`CORS__PORTAL_ORIGIN`:** Set to your **HTTPS ngrok origin** (same URL as the **public** tunnel, e.g. `https://xyz.ngrok-free.app`) so the API allows browser requests from the portal. Without this, login/API calls from the internet can fail with CORS.
 
 7. **Runner user** must be in the **`docker`** group (`sudo usermod -aG docker $USER` and re-login).
 
 ### `Bind for 0.0.0.0:8080 failed: port is already allocated`
 
-Something else is using **3000** or **8080** (often an old `cargohub` container or a manual `docker run`). The deploy workflow now runs **`compose down`**, removes **`cargohub`**, then removes any container bound to those ports before starting.
+Something else is using **8888**, **3000**, or **8080** (often an old `cargohub` container or a manual `docker run`). The deploy workflow now runs **`compose down`**, removes **`cargohub`**, then removes any container bound to those ports before starting.
 
 **Manual fix on the Mac:**
 
 ```bash
 docker compose -f docker-compose.one.yml down --remove-orphans
 docker rm -f cargohub 2>/dev/null || true
+docker ps -q --filter publish=8888 | xargs -r docker rm -f
 docker ps -q --filter publish=8080 | xargs -r docker rm -f
 docker ps -q --filter publish=3000 | xargs -r docker rm -f
 ```

--- a/SECRETS.md
+++ b/SECRETS.md
@@ -64,8 +64,10 @@ This runs `gh secret set --env-file .env`, which creates/updates one GitHub secr
 | `Jwt__SigningKey` | JWT token signing (32+ chars) |
 | `Jwt__Issuer` | JWT issuer claim |
 | `Jwt__Audience` | JWT audience claim |
-| `NEXT_PUBLIC_API_URL` | Portal → API URL (Vercel build) |
-| `Cors__PortalOrigin` | CORS allowed origin |
+| `NEXT_PUBLIC_API_URL` | Portal → API URL (local/Vercel). Docker all-in-one image uses `__SAME_ORIGIN__` at build time |
+| `Cors__PortalOrigin` | CORS allowed origin (e.g. `http://localhost:3000`) |
+| `CORS__PORTAL_ORIGIN` | Same as above when using `docker-compose.one.yml` / Mac runner `.env` — set to **HTTPS ngrok origin** for remote demos |
+| `NGROK_AUTHTOKEN` | Optional: in-container ngrok in `Dockerfile.all-in-one` (tunnel to nginx **:8888**) |
 | `Cors__PortalOrigins__0`, `__1`, … | Multiple CORS origins |
 | `Smtp__Host` | SMTP server |
 | `Smtp__Port` | SMTP port |

--- a/docker-compose.one.yml
+++ b/docker-compose.one.yml
@@ -1,5 +1,6 @@
-# Single image: db + api + portal. One command: docker compose -f docker-compose.one.yml up -d
-# Portal: http://localhost:3000  |  API: http://localhost:8080
+# Single image: db + api + portal + nginx. One command: docker compose -f docker-compose.one.yml up -d
+# Direct: http://localhost:3000 (portal), http://localhost:8080 (API)
+# Public demo: ngrok tunnels to **8888** (nginx: UI + /api). Set CORS__PORTAL_ORIGIN to your https ngrok URL.
 
 services:
   cargohub:
@@ -8,6 +9,7 @@ services:
     pull_policy: always
     container_name: cargohub
     ports:
+      - "8888:8888"
       - "3000:3000"
       - "8080:8080"
       # ngrok local API / dashboard (only when NGROK_AUTHTOKEN is set — see Dockerfile.all-in-one)

--- a/docker/nginx-public.conf
+++ b/docker/nginx-public.conf
@@ -1,0 +1,30 @@
+# Single public entry (port 8888): UI on Next :3000, API on ASP.NET :8080
+# ngrok should tunnel to 8888 only — browser uses one origin so NEXT_PUBLIC can be same-origin.
+
+server {
+    listen 8888;
+    server_name _;
+
+    # ASP.NET Core APIs (/api/v1/...)
+    location /api/ {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    # Next.js ( /en/..., /_next/..., etc.)
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/docker/start-all-in-one.sh
+++ b/docker/start-all-in-one.sh
@@ -28,7 +28,7 @@ gosu postgres psql -tc "SELECT 1 FROM pg_database WHERE datname = 'portal'" | gr
 export ASPNETCORE_ENVIRONMENT=Production
 export PORT=8080
 export ConnectionStrings__DefaultConnection="Host=localhost;Port=5432;Database=portal;Username=postgres;Password=postgres"
-export Cors__PortalOrigin="http://localhost:3000"
+export Cors__PortalOrigin="${Cors__PortalOrigin:-http://localhost:3000}"
 export Bootstrap__Secret="${Bootstrap__Secret:-SuperAdminBootstrapSecret}"
 export Jwt__SigningKey="${Jwt__SigningKey:-DemoJwtKey-ChangeMe-AtLeast32Chars}"
 cd /app/api && dotnet CargoHub.Api.dll &
@@ -37,13 +37,30 @@ APIPID=$!
 # Give API time to start and run migrations
 sleep 5
 
-# Optional: ngrok inside the container (set NGROK_AUTHTOKEN at docker run / compose)
-# Public URLs: open http://localhost:4040 on the host when port 4040 is published, or check container logs
+# Next.js on :3000 (nginx will expose :8888 to the internet via ngrok)
+cd /app/portal
+export NODE_ENV=production
+export PORT=3000
+export HOSTNAME=0.0.0.0
+npm run start &
+NEXT_PID=$!
+
+echo "Waiting for Next.js on :3000..."
+sleep 12
+
+# Reverse proxy: one public port — /api -> ASP.NET :8080, / -> Next :3000
+if nginx -t 2>/dev/null; then
+  nginx
+  echo "nginx listening on :8888 ( /api -> :8080, / -> :3000 )"
+else
+  echo "WARNING: nginx -t failed"; nginx -t || true
+fi
+
+# ngrok: single tunnel to :8888 (not 3000/8080) so browser has one origin for UI + API
 if [ -n "$NGROK_AUTHTOKEN" ]; then
-  echo "Starting ngrok (in-container)..."
+  echo "Starting ngrok (in-container) -> :8888..."
   ngrok config add-authtoken "$NGROK_AUTHTOKEN" 2>/dev/null || true
   ngrok start --all --config /etc/ngrok/ngrok.yml >> /tmp/ngrok.log 2>&1 &
-  # Wait until API responds (tunnels may take a few more seconds)
   i=0
   while [ "$i" -lt 60 ]; do
     if curl -fsS "http://127.0.0.1:4040/api/tunnels" >/dev/null 2>&1; then
@@ -63,10 +80,5 @@ if [ -n "$NGROK_AUTHTOKEN" ]; then
   fi
 fi
 
-# Start Portal (foreground - keeps container alive)
-# HOSTNAME=0.0.0.0 required so Next.js accepts connections from outside container
-cd /app/portal
-export NODE_ENV=production
-export PORT=3000
-export HOSTNAME=0.0.0.0
-exec npm run start
+echo "Public demo: use ngrok HTTPS URL on port 8888 (nginx). Paths: /en/login, /en/dashboard — not /dashboard alone."
+wait "$NEXT_PID"

--- a/ngrok.yml
+++ b/ngrok.yml
@@ -1,13 +1,9 @@
-# Used by GitHub Actions on your self-hosted Mac to expose portal (3000) + API (8080).
-# Auth token comes from repo secret NGROK_AUTHTOKEN (not stored in this file).
-# https://ngrok.com/docs/agent/config/v2/
-# Bind web UI / API on all interfaces so host can reach :4040 via docker -p 4040:4040
+# Single tunnel to nginx :8888 — nginx proxies / -> Next :3000 and /api -> ASP.NET :8080.
+# One public URL = same origin for browser + API (portal uses NEXT_PUBLIC __SAME_ORIGIN__).
+# Auth token: NGROK_AUTHTOKEN at runtime.
 version: "2"
 web_addr: 0.0.0.0:4040
 tunnels:
-  portal:
+  public:
     proto: http
-    addr: 3000
-  api:
-    proto: http
-    addr: 8080
+    addr: 8888

--- a/portal/src/lib/api.ts
+++ b/portal/src/lib/api.ts
@@ -1,7 +1,30 @@
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:5299';
-const BASE = `${API_URL}/api/v1/portal`;
-const ADMIN_BASE = `${API_URL}/api/v1/admin`;
-const COMPANY_BASE = `${API_URL}/api/v1/company`;
+/**
+ * API base URL. In Docker + nginx + single ngrok URL, use __SAME_ORIGIN__ so the browser
+ * calls /api on the same host as the UI. SSR uses 127.0.0.1:8080 inside the container.
+ */
+function getApiUrl(): string {
+  const env = process.env.NEXT_PUBLIC_API_URL;
+  if (typeof window !== 'undefined') {
+    if (!env || env === '__SAME_ORIGIN__') {
+      return window.location.origin;
+    }
+    return env;
+  }
+  if (!env || env === '__SAME_ORIGIN__') {
+    return 'http://127.0.0.1:8080';
+  }
+  return env;
+}
+
+function portalBase(): string {
+  return `${getApiUrl()}/api/v1/portal`;
+}
+function adminBase(): string {
+  return `${getApiUrl()}/api/v1/admin`;
+}
+function companyBase(): string {
+  return `${getApiUrl()}/api/v1/company`;
+}
 
 export type LoginResponse = {
   userId: string;
@@ -30,7 +53,7 @@ export type RegisterBody = {
 };
 
 export async function login(account: string, password: string): Promise<LoginResult> {
-  const res = await fetch(`${BASE}/login`, {
+  const res = await fetch(`${portalBase()}/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ account, password }),
@@ -57,7 +80,7 @@ export async function login(account: string, password: string): Promise<LoginRes
 }
 
 export async function register(body: RegisterBody): Promise<LoginResult> {
-  const res = await fetch(`${BASE}/register`, {
+  const res = await fetch(`${portalBase()}/register`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -75,7 +98,7 @@ export async function register(body: RegisterBody): Promise<LoginResult> {
 export type AuthResult = { success: boolean; message?: string | null };
 
 export async function requestPasswordReset(email: string): Promise<AuthResult> {
-  const res = await fetch(`${BASE}/requestPasswordReset`, {
+  const res = await fetch(`${portalBase()}/requestPasswordReset`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ email }),
@@ -88,7 +111,7 @@ export async function requestPasswordReset(email: string): Promise<AuthResult> {
 }
 
 export async function resetPassword(token: string, newPassword: string): Promise<AuthResult> {
-  const res = await fetch(`${BASE}/resetPassword`, {
+  const res = await fetch(`${portalBase()}/resetPassword`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ token, newPassword }),
@@ -109,7 +132,7 @@ export type BrandingResponse = {
 };
 
 export async function getBranding(): Promise<BrandingResponse> {
-  const res = await fetch(`${BASE}/branding`);
+  const res = await fetch(`${portalBase()}/branding`);
   if (!res.ok) {
     return { appName: 'Portal', logoUrl: '', primaryColor: '', secondaryColor: '' };
   }
@@ -135,7 +158,7 @@ export type PortalMeResponse = {
 };
 
 export async function getMe(token: string): Promise<PortalMeResponse> {
-  const res = await fetch(`${BASE}/me`, {
+  const res = await fetch(`${portalBase()}/me`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) throw new Error('Failed to load current user');
@@ -158,7 +181,7 @@ export type DesignTheme = (typeof DESIGN_THEMES)[number];
 
 /** Update user theme preference (PATCH /api/v1/portal/me/preferences). */
 export async function updateTheme(token: string, theme: string): Promise<void> {
-  const res = await fetch(`${BASE}/me/preferences`, {
+  const res = await fetch(`${portalBase()}/me/preferences`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify({ theme }),
@@ -171,7 +194,7 @@ export async function updateTheme(token: string, theme: string): Promise<void> {
 
 /** Registered courier IDs for the booking form dropdown (GET /api/v1/portal/couriers). */
 export async function getCouriers(token: string): Promise<string[]> {
-  const res = await fetch(`${BASE}/couriers`, {
+  const res = await fetch(`${portalBase()}/couriers`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) throw new Error('Failed to load couriers');
@@ -198,7 +221,7 @@ export type AdminUser = {
 };
 
 export async function adminGetCompanies(token: string): Promise<AdminCompany[]> {
-  const res = await fetch(`${ADMIN_BASE}/companies`, {
+  const res = await fetch(`${adminBase()}/companies`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) {
@@ -210,7 +233,7 @@ export async function adminGetCompanies(token: string): Promise<AdminCompany[]> 
 }
 
 export async function adminGetUsers(token: string, businessId?: string | null): Promise<AdminUser[]> {
-  const url = businessId ? `${ADMIN_BASE}/users?businessId=${encodeURIComponent(businessId)}` : `${ADMIN_BASE}/users`;
+  const url = businessId ? `${adminBase()}/users?businessId=${encodeURIComponent(businessId)}` : `${adminBase()}/users`;
   const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
   if (!res.ok) throw new Error('Failed to load users');
   return res.json();
@@ -221,7 +244,7 @@ export async function adminPatchUser(
   userId: string,
   body: { role?: string; isActive?: boolean }
 ): Promise<void> {
-  const res = await fetch(`${ADMIN_BASE}/users/${encodeURIComponent(userId)}`, {
+  const res = await fetch(`${adminBase()}/users/${encodeURIComponent(userId)}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify(body),
@@ -253,7 +276,7 @@ export type CompanyCreated = {
 };
 
 export async function createCompany(token: string, body: CreateCompanyBody): Promise<CompanyCreated> {
-  const res = await fetch(COMPANY_BASE, {
+  const res = await fetch(companyBase(), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify(body),
@@ -300,7 +323,7 @@ export async function getAddressBook(
   token: string,
   options?: { companyId?: string }
 ): Promise<AddressBookListResponse> {
-  const url = new URL(`${BASE}/company/address-book`);
+  const url = new URL(`${portalBase()}/company/address-book`);
   if (options?.companyId) url.searchParams.set('companyId', options.companyId);
   const res = await fetch(url.toString(), {
     headers: { Authorization: `Bearer ${token}` },
@@ -313,7 +336,7 @@ export async function getAddressBook(
 }
 
 export async function addSender(token: string, entry: AddressEntry, companyId?: string | null): Promise<AddressEntry> {
-  const url = new URL(`${BASE}/company/senders`);
+  const url = new URL(`${portalBase()}/company/senders`);
   if (companyId) url.searchParams.set('companyId', companyId);
   const res = await fetch(url.toString(), {
     method: 'POST',
@@ -328,7 +351,7 @@ export async function addSender(token: string, entry: AddressEntry, companyId?: 
 }
 
 export async function addReceiver(token: string, entry: AddressEntry, companyId?: string | null): Promise<AddressEntry> {
-  const url = new URL(`${BASE}/company/receivers`);
+  const url = new URL(`${portalBase()}/company/receivers`);
   if (companyId) url.searchParams.set('companyId', companyId);
   const res = await fetch(url.toString(), {
     method: 'POST',
@@ -504,7 +527,7 @@ export type CreateBookingBody = {
 };
 
 export async function bookingList(token: string, skip = 0, take = 100): Promise<BookingListItem[]> {
-  const res = await fetch(`${BASE}/bookings?skip=${skip}&take=${take}`, {
+  const res = await fetch(`${portalBase()}/bookings?skip=${skip}&take=${take}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) throw new Error('Failed to load bookings');
@@ -512,7 +535,7 @@ export async function bookingList(token: string, skip = 0, take = 100): Promise<
 }
 
 export async function bookingGet(token: string, id: string): Promise<BookingDetail> {
-  const res = await fetch(`${BASE}/bookings/${id}`, {
+  const res = await fetch(`${portalBase()}/bookings/${id}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) {
@@ -524,7 +547,7 @@ export async function bookingGet(token: string, id: string): Promise<BookingDeta
 
 /** Fetches waybill PDF for a completed booking. Returns a blob URL to open/print. Revoke with URL.revokeObjectURL after use. */
 export async function getWaybillPdfBlobUrl(token: string, bookingId: string): Promise<string> {
-  const res = await fetch(`${BASE}/bookings/${bookingId}/waybill`, {
+  const res = await fetch(`${portalBase()}/bookings/${bookingId}/waybill`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) {
@@ -548,7 +571,7 @@ function apiError(res: Response, data: Record<string, unknown>, fallback: string
 }
 
 export async function bookingCreate(token: string, body: CreateBookingBody): Promise<BookingDetail> {
-  const res = await fetch(`${BASE}/bookings`, {
+  const res = await fetch(`${portalBase()}/bookings`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify(body),
@@ -567,7 +590,7 @@ export async function bookingCreate(token: string, body: CreateBookingBody): Pro
 // --- Drafts: save as draft, retrieve, fill rest, confirm to complete ---
 
 export async function draftList(token: string, skip = 0, take = 100): Promise<BookingListItem[]> {
-  const res = await fetch(`${BASE}/bookings/draft?skip=${skip}&take=${take}`, {
+  const res = await fetch(`${portalBase()}/bookings/draft?skip=${skip}&take=${take}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) throw new Error('Failed to load drafts');
@@ -575,7 +598,7 @@ export async function draftList(token: string, skip = 0, take = 100): Promise<Bo
 }
 
 export async function draftGet(token: string, id: string): Promise<BookingDetail> {
-  const res = await fetch(`${BASE}/bookings/draft/${id}`, {
+  const res = await fetch(`${portalBase()}/bookings/draft/${id}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) {
@@ -586,7 +609,7 @@ export async function draftGet(token: string, id: string): Promise<BookingDetail
 }
 
 export async function draftCreate(token: string, body: CreateBookingBody): Promise<BookingDetail> {
-  const res = await fetch(`${BASE}/bookings/draft`, {
+  const res = await fetch(`${portalBase()}/bookings/draft`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify(body),
@@ -601,7 +624,7 @@ export async function draftCreate(token: string, body: CreateBookingBody): Promi
 export type UpdateDraftBody = CreateBookingBody;
 
 export async function draftUpdate(token: string, id: string, body: UpdateDraftBody): Promise<BookingDetail> {
-  const res = await fetch(`${BASE}/bookings/draft/${id}`, {
+  const res = await fetch(`${portalBase()}/bookings/draft/${id}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify(body),
@@ -615,7 +638,7 @@ export async function draftUpdate(token: string, id: string, body: UpdateDraftBo
 }
 
 export async function draftConfirm(token: string, id: string): Promise<BookingDetail> {
-  const res = await fetch(`${BASE}/bookings/draft/${id}/confirm`, {
+  const res = await fetch(`${portalBase()}/bookings/draft/${id}/confirm`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` },
   });
@@ -641,7 +664,7 @@ export type DashboardStats = {
 };
 
 export async function getDashboardStats(token: string): Promise<DashboardStats> {
-  const res = await fetch(`${BASE}/dashboard/stats`, {
+  const res = await fetch(`${portalBase()}/dashboard/stats`, {
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!res.ok) throw new Error('Failed to load dashboard stats');

--- a/scripts/show-ngrok-public-urls.py
+++ b/scripts/show-ngrok-public-urls.py
@@ -20,7 +20,9 @@ def main():
         url = (t.get("public_url") or "").strip()
         if not url:
             continue
-        if name == "portal":
+        if name == "public":
+            label = "Public app (nginx :8888 — portal + /api)"
+        elif name == "portal":
             label = "Portal (Next.js UI)"
         elif name == "api":
             label = "API (backend)"
@@ -47,10 +49,23 @@ def main():
     if summary_path and rows:
         lines = [f"| **{lbl}** | `{u}` |" for lbl, u in rows]
         table = "\n".join(lines)
+        first_url = rows[0][1] if rows else ""
+        if first_url:
+            tip = (
+                f"**Tip:** Open **`{first_url}/en/login`** (or **`/en/dashboard`**). "
+                f"**`/dashboard` alone returns 404.** Set **`CORS__PORTAL_ORIGIN`** to `{first_url}` "
+                "if API calls fail (CORS).\n\n"
+            )
+        else:
+            tip = (
+                "**Tip:** Use locale paths (`/en/login`, `/en/dashboard`). "
+                "Set **`CORS__PORTAL_ORIGIN`** to the HTTPS origin if API calls fail.\n\n"
+            )
         body = (
             "## Public URLs (remote access)\n\n"
             "Open these from **any browser** (internet). On the Mac: **http://localhost:4040** "
             "for the ngrok dashboard.\n\n"
+            f"{tip}"
             "| Service | URL |\n"
             "|---------|-----|\n"
             f"{table}\n\n"


### PR DESCRIPTION
- Add nginx-public.conf; tunnel ngrok to 8888 (UI + /api)
- Portal: __SAME_ORIGIN__ + getApiUrl() for browser
- start-all-in-one: nginx + ngrok; CORS from env
- Mac workflow: smoke test :8888; free port 8888
- Docs: RUN.md, CLAUDE.md, SECRETS.md, .env.example

Made-with: Cursor