### PR TITLE
chore: align master tree with main/development

### DIFF
--- a/docker/start-all-in-one.sh
+++ b/docker/start-all-in-one.sh
@@ -37,7 +37,7 @@ APIPID=$!
 # Give API time to start and run migrations
 sleep 5
 
-# Next.js on :3000 (HOSTNAME=0.0.0.0); nginx exposes :8888 for public/ngrok
+# Next.js on :3000 (nginx will expose :8888 to the internet via ngrok)
 cd /app/portal
 export NODE_ENV=production
 export PORT=3000


### PR DESCRIPTION
Makes **\docker/start-all-in-one.sh\** match **\main\** exactly (one comment line). After merge, **\main\**, **\development\**, and **\master\** have **identical file trees** (verified with \git diff\).

Made with [Cursor](https://cursor.com)