### PR TITLE
ci: stop cancelling in-flight Mac deploy runs

### DIFF
--- a/.github/workflows/push-docker-mac.yml
+++ b/.github/workflows/push-docker-mac.yml
@@ -15,9 +15,11 @@ on:
     branches: [main, master, development]
   workflow_dispatch:
 
+# Do not cancel in-flight runs: a new push to the same branch would otherwise kill the Mac
+# deploy mid-pull (looks like random failures/cancellations). Queued runs wait instead.
 concurrency:
   group: docker-mac-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## What \gh\ showed

### Recent **Docker Hub + Mac deploy** runs
| Result | Cause |
|--------|--------|
| **cancelled** (e.g. run on PR #42 merge) | **Concurrency**: \cancel-in-progress: true\ — a newer push to **\master\** cancelled the previous run while **Deploy on Mac** was still running. |
| **failure** (e.g. run #37) | **Docker Hub** \uth.docker.io\ **timeout** before we added login + retries on the Mac job (older workflow). |
| **success** | Runs #38–39 after fixes; authenticated pull + retries. |
| **in_progress** (stuck / long) | Check runner: self-hosted job can sit on pull or smoke test; re-run or inspect Mac. |

### This PR
Sets \cancel-in-progress: false\ so a new push **queues** instead of **killing** an active Mac deploy.

Merge to \development\ → then \main\/\master\ as usual.

Made with [Cursor](https://cursor.com)