### PR TITLE
ci: auto-create GitHub issues on deploy / PR validation failure

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -153,3 +153,45 @@ jobs:
             FAIL=1
           fi
           if [ $FAIL -eq 1 ]; then exit 1; fi
+
+  # Does not run for fork PRs (token cannot open issues in the base repo from forks).
+  notify-pr-failure:
+    name: Open GitHub issue on PR validation failure
+    needs: [build-and-test]
+    if: |
+      failure() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const branch = pr?.head?.ref || context.ref.replace('refs/heads/', '');
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const prLine = pr
+              ? `| **PR** | #${pr.number} — ${pr.title} |`
+              : '| **PR** | (workflow_dispatch) |';
+            const title = `[CI] PR Validation failed — ${branch} (run ${context.runId})`;
+            const body = [
+              '### PR Validation (tests / coverage) failed',
+              '',
+              '| | |',
+              '|-|-|',
+              prLine,
+              `| **Branch** | \`${branch}\` |`,
+              `| **Commit** | \`${context.sha}\` |`,
+              '',
+              `**[View run logs →](${runUrl})**`,
+              '',
+              '_Issue created automatically when PR Validation fails._',
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+            });
+            console.log('Created GitHub issue for failed PR validation.');

--- a/.github/workflows/push-docker-mac.yml
+++ b/.github/workflows/push-docker-mac.yml
@@ -184,3 +184,49 @@ jobs:
           echo "$TUNNELS" | python3 scripts/show-ngrok-public-urls.py
           echo ""
           echo "(See the **Summary** tab on this job for a copy-friendly table.)"
+
+  # Opens one issue per failed run (title includes run id — not deduplicated).
+  notify-failure:
+    name: Open GitHub issue on pipeline failure
+    needs: [build-and-push, deploy-on-mac]
+    if: ${{ always() && (needs['build-and-push'].result == 'failure' || needs['deploy-on-mac'].result == 'failure') }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      BUILD_RESULT: ${{ needs['build-and-push'].result }}
+      DEPLOY_RESULT: ${{ needs['deploy-on-mac'].result }}
+    steps:
+      - name: Create issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ref = context.ref.replace('refs/heads/', '');
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const build = process.env.BUILD_RESULT || '';
+            const deploy = process.env.DEPLOY_RESULT || '';
+            const failed = [];
+            if (build === 'failure') failed.push('build-and-push (Docker build/push)');
+            if (deploy === 'failure') failed.push('deploy-on-mac (Mac pull/smoke/ngrok)');
+            const title = `[CI] Docker + Mac deploy failed — ${ref} (run ${context.runId})`;
+            const body = [
+              '### Failed job(s)',
+              failed.map(f => `- **${f}**`).join('\n') || '- (unknown)',
+              '',
+              '| | |',
+              '|-|-|',
+              `| **Branch** | \`${ref}\` |`,
+              `| **Commit** | \`${context.sha}\` |`,
+              `| **Workflow** | \`${context.workflow}\` |`,
+              '',
+              `**[View run logs →](${runUrl})**`,
+              '',
+              '_Issue created automatically when this workflow fails._',
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+            });
+            console.log('Created GitHub issue for failed deploy pipeline.');

--- a/RUN.md
+++ b/RUN.md
@@ -83,6 +83,10 @@ PostgreSQL data is stored in a Docker volume. Use `docker compose down -v` to re
 
 ## Test the GitHub Actions pipeline
 
+### Automatic GitHub issues on failure
+
+When **PR Validation** or **Docker Hub + Mac deploy + ngrok** fails, the workflow opens a **new issue** in this repo with a link to the failed run (title includes the workflow run id). Fork PRs do not get an issue (GitHub token limits). You can close or label these like any other issue.
+
 ### One automated release (push to `main` / `master` / `development`)
 
 **Workflow: Docker Hub + Mac deploy + ngrok**


### PR DESCRIPTION
## Summary
- **Docker Hub + Mac deploy + ngrok:** after a failed \uild-and-push\ or \deploy-on-mac\, opens an issue with branch, commit, failed job names, and link to the run.
- **PR Validation:** after \uild-and-test\ fails, opens an issue (includes PR # and title when applicable). **Skipped for fork PRs** (token cannot create issues in the base repo).

Uses \ctions/github-script\ on \ubuntu-latest\ (no \gh\ required on the Mac runner). Each failure creates **one new issue** (title includes run id).

**Docs:** \RUN.md\ — short section on this behavior.

Made with [Cursor](https://cursor.com)