### PR TITLE
chore: sync development → main (CI pipelines, deploy summary)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,35 +1,27 @@
-# PR validation: build, test, and coverage on every pull request
-# Runs on GitHub-hosted runners — no server needed
-#
-# To block direct commits: Settings → Branches → Add rule for main & development
-#   - Require a pull request before merging
-#   - Require status checks (this workflow) to pass
+# Single responsibility per job:
+#   1. portal-ci      — Node, Vitest, portal coverage artifact
+#   2. backend-ci     — .NET build/test, backend coverage artifact
+#   3. coverage-gates — download both artifacts, summary + 75% enforcement
+#   4. notify-pr-failure — issue on fork-safe branches only
 
 name: PR Validation
 
 on:
   pull_request:
     branches: [main, master, development]
-  # Manual: Actions → PR Validation → Run workflow (full test + coverage gates)
   workflow_dispatch:
 
 jobs:
-  build-and-test:
+  portal-ci:
+    name: 1 — Portal (Vitest + coverage)
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0.x'
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          # Vitest 4 / rolldown requires util.styleText (Node 20.12+)
           node-version-file: portal/.nvmrc
 
       - name: Install portal dependencies
@@ -38,11 +30,24 @@ jobs:
       - name: Portal test with coverage
         run: cd portal && npm run test:coverage
 
-      - name: Upload portal coverage
+      - name: Upload portal coverage artifact
         uses: actions/upload-artifact@v4
         with:
           name: portal-coverage
           path: portal/coverage/
+          retention-days: 14
+
+  backend-ci:
+    name: 2 — Backend (.NET + coverage)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
 
       - name: Restore
         run: dotnet restore CargoHub.Backend.sln
@@ -67,15 +72,45 @@ jobs:
             -targetdir:"./CoverageReport" \
             -reporttypes:"Html;HtmlSummary;Badges"
 
-      - name: Upload coverage report
+      - name: Upload TestResults (coverage)
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-testresults
+          path: TestResults/
+          retention-days: 14
+
+      - name: Upload HTML coverage report
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: CoverageReport/
+          retention-days: 14
 
-      - name: Coverage summary
+  coverage-gates:
+    name: 3 — Coverage thresholds (75%)
+    needs: [portal-ci, backend-ci]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (for scripts consistency)
+        uses: actions/checkout@v4
+
+      - name: Install jq and bc
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq jq bc
+
+      - name: Download portal coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: portal-coverage
+          path: portal/coverage
+
+      - name: Download backend TestResults
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-testresults
+          path: TestResults
+
+      - name: Coverage summary (Job Summary)
         run: |
-          # Backend coverage
           COV_FILE=$(find ./TestResults -name "coverage.cobertura.xml" -print -quit 2>/dev/null)
           BACKEND_LINE="N/A"
           BACKEND_BRANCH="N/A"
@@ -85,16 +120,12 @@ jobs:
             BRANCH_RATE=$(grep -m1 -o 'branch-rate="[^"]*"' "$COV_FILE" 2>/dev/null | cut -d'"' -f2)
             [ -n "$BRANCH_RATE" ] && BACKEND_BRANCH=$(awk "BEGIN {printf \"%.1f\", $BRANCH_RATE*100}" 2>/dev/null)
           fi
-
-          # Portal (frontend) coverage
           PORTAL_LINE="N/A"
           PORTAL_BRANCH="N/A"
           if [ -f portal/coverage/coverage-summary.json ]; then
             PORTAL_LINE=$(jq -r '.total.lines.pct' portal/coverage/coverage-summary.json 2>/dev/null || echo "N/A")
             PORTAL_BRANCH=$(jq -r '.total.branches.pct' portal/coverage/coverage-summary.json 2>/dev/null || echo "N/A")
           fi
-
-          # Build Markdown report (displayed on the job page and in step log)
           {
             echo "## Coverage Report"
             echo ""
@@ -110,14 +141,14 @@ jobs:
             echo "| **Line** | ${PORTAL_LINE}% | 75% min |"
             echo "| **Branch** | ${PORTAL_BRANCH}% | 75% min |"
             echo ""
-            echo "**Artifacts:** Backend HTML report: **coverage-report** | Portal HTML report: **portal-coverage**"
-          } | tee -a $GITHUB_STEP_SUMMARY
+            echo "**Artifacts:** Backend HTML: **coverage-report** | Portal: **portal-coverage**"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
-      - name: Enforce backend coverage threshold (75% line and branch minimum)
+      - name: Enforce backend coverage (75% line & branch)
         run: |
           COV_FILE=$(find ./TestResults -name "coverage.cobertura.xml" -print -quit 2>/dev/null)
           if [ -z "$COV_FILE" ] || [ ! -f "$COV_FILE" ]; then
-            echo "Backend coverage file not found"
+            echo "::error::Backend coverage file not found"
             exit 1
           fi
           LINE_RATE=$(grep -m1 -o 'line-rate="[^"]*"' "$COV_FILE" | cut -d'"' -f2)
@@ -126,40 +157,41 @@ jobs:
           BRANCH_PCT=$(echo "$BRANCH_RATE * 100" | bc)
           FAIL=0
           if (( $(echo "$LINE_PCT < 75" | bc -l) )); then
-            echo "::error::Backend line coverage ${LINE_PCT}% is below 75% minimum - PR cannot merge"
+            echo "::error::Backend line coverage ${LINE_PCT}% is below 75% minimum"
             FAIL=1
           fi
           if (( $(echo "$BRANCH_PCT < 75" | bc -l) )); then
-            echo "::error::Backend branch coverage ${BRANCH_PCT}% is below 75% minimum - PR cannot merge"
+            echo "::error::Backend branch coverage ${BRANCH_PCT}% is below 75% minimum"
             FAIL=1
           fi
           if [ $FAIL -eq 1 ]; then exit 1; fi
 
-      - name: Enforce portal coverage threshold (75% line and branch minimum)
+      - name: Enforce portal coverage (75% line & branch)
         run: |
           if [ ! -f portal/coverage/coverage-summary.json ]; then
-            echo "Portal coverage file not found"
+            echo "::error::Portal coverage file not found"
             exit 1
           fi
           LINE_PCT=$(jq -r '.total.lines.pct' portal/coverage/coverage-summary.json)
           BRANCH_PCT=$(jq -r '.total.branches.pct' portal/coverage/coverage-summary.json)
           FAIL=0
           if (( $(echo "$LINE_PCT < 75" | bc -l) )); then
-            echo "::error::Portal line coverage ${LINE_PCT}% is below 75% minimum - PR cannot merge"
+            echo "::error::Portal line coverage ${LINE_PCT}% is below 75% minimum"
             FAIL=1
           fi
           if (( $(echo "$BRANCH_PCT < 75" | bc -l) )); then
-            echo "::error::Portal branch coverage ${BRANCH_PCT}% is below 75% minimum - PR cannot merge"
+            echo "::error::Portal branch coverage ${BRANCH_PCT}% is below 75% minimum"
             FAIL=1
           fi
           if [ $FAIL -eq 1 ]; then exit 1; fi
 
-  # Does not run for fork PRs (token cannot open issues in the base repo from forks).
   notify-pr-failure:
-    name: Open GitHub issue on PR validation failure
-    needs: [build-and-test]
+    name: 4 — Open issue on failure
+    needs: [portal-ci, backend-ci, coverage-gates]
     if: |
-      failure() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+      always() &&
+      (needs['portal-ci'].result == 'failure' || needs['backend-ci'].result == 'failure' || needs['coverage-gates'].result == 'failure') &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -174,9 +206,14 @@ jobs:
             const prLine = pr
               ? `| **PR** | #${pr.number} — ${pr.title} |`
               : '| **PR** | (workflow_dispatch) |';
+            const failed = [];
+            if (process.env.PORTAL === 'failure') failed.push('portal-ci');
+            if (process.env.BACKEND === 'failure') failed.push('backend-ci');
+            if (process.env.GATES === 'failure') failed.push('coverage-gates');
             const title = `[CI] PR Validation failed — ${branch} (run ${context.runId})`;
             const body = [
-              '### PR Validation (tests / coverage) failed',
+              '### Failed job(s)',
+              failed.map(f => `- **${f}**`).join('\n') || '- (unknown)',
               '',
               '| | |',
               '|-|-|',
@@ -195,3 +232,7 @@ jobs:
               body,
             });
             console.log('Created GitHub issue for failed PR validation.');
+        env:
+          PORTAL: ${{ needs['portal-ci'].result }}
+          BACKEND: ${{ needs['backend-ci'].result }}
+          GATES: ${{ needs['coverage-gates'].result }}

--- a/.github/workflows/push-docker-mac.yml
+++ b/.github/workflows/push-docker-mac.yml
@@ -1,12 +1,10 @@
-# One pipeline: push code → build & push image → deploy on Mac Mini.
-# ngrok runs inside the container when NGROK_AUTHTOKEN is set (no ngrok install on host required).
+# Pipeline layout (single responsibility per job / step):
+#   1. build-image     — Docker Buildx + push only (Ubuntu)
+#   2. deploy-mac       — self-hosted: login → stop → pull → up → smoke → report → ngrok
+#   3. notify-failure   — open GitHub issue if build or deploy failed
 #
-# Secrets (repo → Settings → Secrets → Actions):
-#   DOCKERHUB_USERNAME, DOCKERHUB_TOKEN  — required for build + Mac deploy (authenticated pull; avoids Hub timeouts/rate limits)
-#   NGROK_AUTHTOKEN                      — optional; passed into container for in-image ngrok
-#   BOOTSTRAP__SECRET, JWT__SIGNING_KEY, CORS__PORTAL_ORIGIN — optional for compose
-#
-# Mac Mini: Docker + self-hosted runner (ngrok binary on host not required).
+# Secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN (build + Mac pull)
+#          NGROK_AUTHTOKEN, BOOTSTRAP__SECRET, JWT__SIGNING_KEY, CORS__PORTAL_ORIGIN (optional)
 
 name: Docker Hub + Mac deploy + ngrok
 
@@ -15,34 +13,35 @@ on:
     branches: [main, master, development]
   workflow_dispatch:
 
-# Do not cancel in-flight runs: a new push to the same branch would otherwise kill the Mac
-# deploy mid-pull (looks like random failures/cancellations). Queued runs wait instead.
 concurrency:
   group: docker-mac-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  build-and-push:
-    name: Build and push image
+  # --- Job 1: produce container image only ---
+  build-image:
+    name: 1 — Build & push image (Ubuntu)
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
+    outputs:
+      image_digest: ${{ steps.push.outputs.digest }}
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract metadata
+      - name: Compute image tags & labels
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -51,7 +50,8 @@ jobs:
             type=raw,value=latest
             type=sha,prefix=
 
-      - name: Build and push (all-in-one)
+      - name: Build and push (Dockerfile.all-in-one)
+        id: push
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -62,19 +62,48 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  deploy-on-mac:
-    name: Deploy on Mac + smoke + ngrok URLs
-    needs: build-and-push
+  # --- Job 2: Mac runner only (deploy + verify + reporting) ---
+  deploy-mac:
+    name: 2 — Deploy on Mac (pull, compose, smoke, ngrok)
+    needs: build-image
     runs-on: self-hosted
+    env:
+      COMPOSE_HTTP_TIMEOUT: "600"
+      IMAGE_DIGEST: ${{ needs.build-image.outputs.image_digest }}
+
     steps:
-      - name: Checkout
+      - name: Print runner & git context
+        run: |
+          set -e
+          echo "=== Runner ==="
+          echo "hostname=$(hostname 2>/dev/null || echo n/a)"
+          uname -a 2>/dev/null || true
+          echo "=== Git ==="
+          echo "ref=${{ github.ref }}"
+          echo "sha=${{ github.sha }}"
+          echo "workflow=${{ github.workflow }}"
+          echo "run_id=${{ github.run_id }}"
+          echo "actor=${{ github.actor }}"
+          echo "=== Image from build job (Ubuntu) ==="
+          echo "digest=$IMAGE_DIGEST"
+
+      - name: Checkout repository (deploy scripts & compose)
         uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
 
-      # Authenticated pulls avoid Docker Hub anonymous rate limits and are more reliable than
-      # unauthenticated pulls (which often hit Client.Timeout / slow auth.docker.io).
-      - name: Login to Docker Hub (for pull on Mac)
+      - name: Set Compose command (optional ~/.cargohub.env)
+        run: |
+          set -e
+          if [ -f "$HOME/.cargohub.env" ]; then
+            echo "COMPOSE_CMD=docker compose -f docker-compose.one.yml --env-file $HOME/.cargohub.env" >> "$GITHUB_ENV"
+            echo "Using ~/.cargohub.env for compose."
+          else
+            echo "COMPOSE_CMD=docker compose -f docker-compose.one.yml" >> "$GITHUB_ENV"
+            echo "No ~/.cargohub.env — compose env from workflow secrets only."
+          fi
+
+      - name: Log in to Docker Hub (authenticated pull)
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -86,26 +115,12 @@ jobs:
             echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
           fi
 
-      - name: Pull latest image and restart stack
-        env:
-          Bootstrap__Secret: ${{ secrets.BOOTSTRAP__SECRET }}
-          Jwt__SigningKey: ${{ secrets.JWT__SIGNING_KEY }}
-          CORS__PORTAL_ORIGIN: ${{ secrets.CORS__PORTAL_ORIGIN }}
-          NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
-          # Longer waits for slow registry / auth.docker.io (default 60s is often too low on home networks)
-          COMPOSE_HTTP_TIMEOUT: "600"
+      - name: Stop stack & free ports (8888, 8080, 3000, 4040)
         run: |
           set -e
-          export COMPOSE_HTTP_TIMEOUT="${COMPOSE_HTTP_TIMEOUT:-600}"
-          COMPOSE="docker compose -f docker-compose.one.yml"
-          if [ -f "$HOME/.cargohub.env" ]; then
-            COMPOSE="$COMPOSE --env-file $HOME/.cargohub.env"
-          fi
-
           echo "Stopping existing stack and freeing ports..."
-          $COMPOSE down --remove-orphans 2>/dev/null || true
+          $COMPOSE_CMD down --remove-orphans 2>/dev/null || true
           docker rm -f cargohub 2>/dev/null || true
-          # Remove any container still bound to host ports (stale manual runs, duplicate stacks)
           for port in 8888 8080 3000 4040; do
             for id in $(docker ps -q --filter "publish=$port" 2>/dev/null); do
               echo "Removing container $id (was using port $port)"
@@ -113,15 +128,19 @@ jobs:
             done
           done
 
+      - name: Pull image (retry)
+        run: |
+          set -e
+          export COMPOSE_HTTP_TIMEOUT="${COMPOSE_HTTP_TIMEOUT:-600}"
           max=6
           n=1
           while [ "$n" -le "$max" ]; do
             echo "docker compose pull (attempt $n/$max, COMPOSE_HTTP_TIMEOUT=$COMPOSE_HTTP_TIMEOUT)..."
-            if $COMPOSE pull; then
+            if $COMPOSE_CMD pull; then
               break
             fi
             if [ "$n" -eq "$max" ]; then
-              echo "::error::docker compose pull failed after $max attempts. Check network, Docker Hub status, and DOCKERHUB_* secrets on the runner."
+              echo "::error::docker compose pull failed after $max attempts."
               exit 1
             fi
             wait_sec=$((n * 20))
@@ -130,72 +149,90 @@ jobs:
             n=$((n+1))
           done
 
-          $COMPOSE up -d --force-recreate --remove-orphans
-
-      - name: Prune old images (optional)
-        run: docker image prune -f || true
-
-      - name: Smoke test (API + portal + nginx :8888)
+      - name: Start stack (compose up)
+        env:
+          Bootstrap__Secret: ${{ secrets.BOOTSTRAP__SECRET }}
+          Jwt__SigningKey: ${{ secrets.JWT__SIGNING_KEY }}
+          CORS__PORTAL_ORIGIN: ${{ secrets.CORS__PORTAL_ORIGIN }}
+          NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
         run: |
           set -e
+          export COMPOSE_HTTP_TIMEOUT="${COMPOSE_HTTP_TIMEOUT:-600}"
+          $COMPOSE_CMD up -d --force-recreate --remove-orphans
+
+      - name: Prune dangling images
+        run: docker image prune -f || true
+
+      - name: Wait for stack boot
+        run: |
           echo "Waiting for Postgres, API, Next.js, nginx..."
           sleep 25
+
+      - name: Smoke — API :8080 health
+        run: |
+          set -e
           curl -sfS --retry 25 --retry-delay 5 --retry-all-errors \
             "http://localhost:8080/api/v1/health_"
+
+      - name: Smoke — Portal :3000
+        run: |
+          set -e
           curl -sfS --retry 25 --retry-delay 5 --retry-all-errors \
             -o /dev/null "http://localhost:3000/"
-          # Same as internet users: nginx :8888 -> /api + Next
+
+      - name: Smoke — Public nginx :8888 (API + UI)
+        run: |
+          set -e
           curl -sfS --retry 25 --retry-delay 5 --retry-all-errors \
             "http://localhost:8888/api/v1/health_"
           curl -sfS --retry 25 --retry-delay 5 --retry-all-errors \
             -o /dev/null "http://localhost:8888/en/"
-          echo "Smoke tests passed (direct :3000/:8080 and public :8888)."
+          echo "Smoke tests passed."
 
-      - name: Show public URLs (ngrok)
+      - name: Write deployment report (Job Summary)
+        run: |
+          set -e
+          chmod +x scripts/ci/deploy-summary.sh 2>/dev/null || true
+          sh scripts/ci/deploy-summary.sh
+
+      - name: Show public ngrok URLs
         continue-on-error: true
         env:
           NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
         run: |
           if [ -z "$NGROK_AUTHTOKEN" ]; then
-            echo "::notice::NGROK_AUTHTOKEN not set — in-container ngrok is disabled. Add repo secret to enable public URLs."
+            echo "::notice::NGROK_AUTHTOKEN not set — in-container ngrok is disabled."
             exit 0
           fi
-
           echo "Waiting for ngrok tunnels (polls localhost:4040, up to ~2 min)..."
           TUNNELS=$(python3 scripts/wait-ngrok-tunnels.py)
           TUNNEL_COUNT=$(echo "$TUNNELS" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('tunnels') or []))" 2>/dev/null || echo 0)
-
           if [ "$TUNNEL_COUNT" = "0" ]; then
             echo "::warning::No ngrok tunnels yet. Diagnostics:"
-            echo "--- curl :4040 (raw) ---"
             curl -sv "http://127.0.0.1:4040/api/tunnels" 2>&1 | tail -30 || true
-            echo "--- docker ps (cargohub) ---"
             docker ps -a --filter name=cargohub --no-trunc 2>/dev/null || true
-            echo "--- docker logs cargohub (last 80 lines) ---"
             docker logs cargohub 2>&1 | tail -80 || true
-            echo "--- /tmp/ngrok.log inside container ---"
-            docker exec cargohub tail -60 /tmp/ngrok.log 2>/dev/null || echo "(no log or container not running)"
+            docker exec cargohub tail -60 /tmp/ngrok.log 2>/dev/null || true
           fi
-
           echo ""
           echo "=========================================="
-          echo "  PUBLIC URLS (share these for remote demo)"
+          echo "  PUBLIC URLS (remote demo)"
           echo "=========================================="
           echo "$TUNNELS" | python3 scripts/show-ngrok-public-urls.py
           echo ""
           echo "(See the **Summary** tab on this job for a copy-friendly table.)"
 
-  # Opens one issue per failed run (title includes run id — not deduplicated).
+  # --- Job 3: failure notification ---
   notify-failure:
-    name: Open GitHub issue on pipeline failure
-    needs: [build-and-push, deploy-on-mac]
-    if: ${{ always() && (needs['build-and-push'].result == 'failure' || needs['deploy-on-mac'].result == 'failure') }}
+    name: 3 — Open issue on failure
+    needs: [build-image, deploy-mac]
+    if: ${{ always() && (needs['build-image'].result == 'failure' || needs['deploy-mac'].result == 'failure') }}
     runs-on: ubuntu-latest
     permissions:
       issues: write
     env:
-      BUILD_RESULT: ${{ needs['build-and-push'].result }}
-      DEPLOY_RESULT: ${{ needs['deploy-on-mac'].result }}
+      BUILD_RESULT: ${{ needs['build-image'].result }}
+      DEPLOY_RESULT: ${{ needs['deploy-mac'].result }}
     steps:
       - name: Create issue
         uses: actions/github-script@v7
@@ -206,8 +243,8 @@ jobs:
             const build = process.env.BUILD_RESULT || '';
             const deploy = process.env.DEPLOY_RESULT || '';
             const failed = [];
-            if (build === 'failure') failed.push('build-and-push (Docker build/push)');
-            if (deploy === 'failure') failed.push('deploy-on-mac (Mac pull/smoke/ngrok)');
+            if (build === 'failure') failed.push('build-image (Docker build/push)');
+            if (deploy === 'failure') failed.push('deploy-mac (Mac pull/smoke/ngrok)');
             const title = `[CI] Docker + Mac deploy failed — ${ref} (run ${context.runId})`;
             const body = [
               '### Failed job(s)',

--- a/RUN.md
+++ b/RUN.md
@@ -83,6 +83,13 @@ PostgreSQL data is stored in a Docker volume. Use `docker compose down -v` to re
 
 ## Test the GitHub Actions pipeline
 
+### Pipeline layout (single responsibility)
+
+| Workflow | Jobs | Purpose |
+|----------|------|--------|
+| **Docker Hub + Mac deploy + ngrok** | `1 — Build & push image (Ubuntu)` → `2 — Deploy on Mac` → `3 — Open issue on failure` | Build image on GitHub-hosted Linux; deploy/smoke/report on your Mac runner. The **Deploy** job prints runner + git context, runs each smoke step separately, and appends a **deployment report** (digest, `docker ps`, `docker images`) to the job **Summary** tab. |
+| **PR Validation** | `1 — Portal` ∥ `2 — Backend` → `3 — Coverage thresholds` → `4 — Open issue on failure` | Portal and backend CI run **in parallel**; coverage gates run only if both succeed. |
+
 ### Automatic GitHub issues on failure
 
 When **PR Validation** or **Docker Hub + Mac deploy + ngrok** fails, the workflow opens a **new issue** in this repo with a link to the failed run (title includes the workflow run id). Fork PRs do not get an issue (GitHub token limits). You can close or label these like any other issue.
@@ -105,10 +112,12 @@ When **PR Validation** or **Docker Hub + Mac deploy + ngrok** fails, the workflo
 
 | Workflow | When it runs | What it tests |
 |----------|----------------|---------------|
-| **PR Validation** | PRs to `main` / `master` / `development`, or **Run workflow** | `npm test` + coverage, `dotnet build` / `dotnet test` + coverage (75% gates) |
+| **PR Validation** | PRs to `main` / `master` / `development`, or **Run workflow** | Portal + backend jobs in **parallel**; then **coverage-gates** (75% min) |
 | **Docker validate (all-in-one)** | Same PRs, or **Run workflow** | `Dockerfile.all-in-one` **builds** (no push to registry) |
 
 **Suggested order to test:** PR Validation → Docker validate → then push to `main` (full release pipeline).
+
+**Branch protection:** If you require status checks before merge, set required checks to **`portal-ci`**, **`backend-ci`**, and **`coverage-gates`** (replacing any old **`build-and-test`** check).
 
 ---
 

--- a/scripts/ci/deploy-summary.sh
+++ b/scripts/ci/deploy-summary.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/sh
+# Append Mac deploy details to GitHub Actions Job Summary ($GITHUB_STEP_SUMMARY).
+# Expects: GITHUB_STEP_SUMMARY, optional IMAGE_DIGEST, IMAGE_TAGS, COMPOSE_PROJECT (default cargohub).
+set -e
+
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+COMPOSE_PROJECT="${COMPOSE_PROJECT:-cargohub}"
+
+{
+  echo "## Deployment report (self-hosted runner)"
+  echo ""
+  echo "### Runner"
+  echo "\`\`\`"
+  echo "hostname: $(hostname 2>/dev/null || echo n/a)"
+  echo "date: $(date -u 2>/dev/null || date)"
+  uname -a 2>/dev/null || true
+  echo "\`\`\`"
+  echo ""
+  echo "### Docker"
+  echo "\`\`\`"
+  docker version --format '{{.Server.Version}}' 2>/dev/null && echo "(server)" || docker version 2>/dev/null | head -5 || echo "docker n/a"
+  echo "\`\`\`"
+  echo ""
+  echo "### Image built in CI (this run)"
+  echo "| | |"
+  echo "|-|-|"
+  if [ -n "${IMAGE_DIGEST:-}" ]; then
+    echo "| **Manifest digest** (from build job) | \`${IMAGE_DIGEST}\` |"
+  else
+    echo "| **Manifest digest** | (not available from build job) |"
+  fi
+  echo ""
+  echo "### Local image after pull"
+  echo "\`\`\`"
+  docker images --format "table {{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.CreatedSince}}\t{{.Size}}" 2>/dev/null | head -20 || echo "docker images n/a"
+  echo "\`\`\`"
+  echo ""
+  echo "### Container (compose project / name: ${COMPOSE_PROJECT})"
+  echo "\`\`\`"
+  docker ps -a --filter "name=${COMPOSE_PROJECT}" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || docker ps -a 2>/dev/null | head -15 || echo "docker ps n/a"
+  echo "\`\`\`"
+  echo ""
+  if docker inspect "${COMPOSE_PROJECT}" >/dev/null 2>&1; then
+    echo "### Inspect ${COMPOSE_PROJECT} (image + ports)"
+    echo "\`\`\`json"
+    docker inspect "${COMPOSE_PROJECT}" --format '{{json .Config.Image}}' 2>/dev/null || true
+    docker inspect "${COMPOSE_PROJECT}" --format '{{range $k,$v := .NetworkSettings.Ports}}{{$k}} -> {{json $v}}{{"\n"}}{{end}}' 2>/dev/null || true
+    echo "\`\`\`"
+  fi
+  echo ""
+  echo "### Endpoints verified by smoke tests"
+  echo "| Service | URL |"
+  echo "|---------|-----|"
+  echo "| API | http://localhost:8080/api/v1/health_ |"
+  echo "| Portal (direct) | http://localhost:3000/ |"
+  echo "| Public (nginx) | http://localhost:8888/en/ |"
+} >> "$SUMMARY"
+
+echo "Wrote deployment report to GitHub Actions Summary."


### PR DESCRIPTION
Syncs **\main\** with **\development\** (post PR #45 and follow-ups).

### Includes
- Fragmented CI jobs (PR Validation: portal + backend + gates; Docker: build-image / deploy-mac)
- Mac deploy summary script, timeouts, troubleshooting docs
- Any other commits on \development\ not yet on \main\

After merge, **\main\** matches **\development\** for these paths.

Made with [Cursor](https://cursor.com)