### PR TITLE
feat(portal): Apache ECharts dashboard with themed options

### DIFF
--- a/portal/package-lock.json
+++ b/portal/package-lock.json
@@ -11,6 +11,8 @@
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
         "lucide-react": "^0.576.0",
         "next": "16.1.7",
         "next-intl": "^4.8.3",
@@ -18,7 +20,6 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
-        "recharts": "^3.7.0",
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
@@ -4286,40 +4287,6 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="
     },
-    "node_modules/@reduxjs/toolkit": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
-      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "@standard-schema/utils": "^0.3.0",
-        "immer": "^11.0.0",
-        "redux": "^5.0.1",
-        "redux-thunk": "^3.1.0",
-        "reselect": "^5.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
-        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-redux": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
-      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.1.tgz",
@@ -4673,16 +4640,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
-    },
-    "node_modules/@standard-schema/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "node_modules/@swc/core-darwin-arm64": {
       "version": "1.15.18",
@@ -5390,60 +5347,6 @@
         "assertion-error": "^2.0.1"
       }
     },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
-    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -5500,11 +5403,6 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
     },
     "node_modules/@types/validate-npm-package-name": {
       "version": "4.0.2",
@@ -7160,116 +7058,6 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true
     },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -7370,11 +7158,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="
-    },
-    "node_modules/decimal.js-light": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -7588,6 +7371,33 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/echarts": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
+      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.0.0"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.6.tgz",
+      "integrity": "sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/eciesjs": {
       "version": "0.4.17",
@@ -7850,11 +7660,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-toolkit": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.0.tgz",
-      "integrity": "sha512-RArCX+Zea16+R1jg4mH223Z8p/ivbJjIkU3oC6ld2bdUfmDxiCkFYSi9zLOR2anucWJUeH4Djnzgd0im0nD3dw=="
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -8364,11 +8169,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
-    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -8490,8 +8290,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -9336,15 +9135,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -9397,14 +9187,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/intl-messageformat": {
@@ -12057,29 +11839,8 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/react-redux": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
-      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
-      "dependencies": {
-        "@types/use-sync-external-store": "^0.0.6",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.2.25 || ^19",
-        "react": "^18.0 || ^19",
-        "redux": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
-      }
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -12163,32 +11924,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/recharts": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
-      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
-      "dependencies": {
-        "@reduxjs/toolkit": "1.x.x || 2.x.x",
-        "clsx": "^2.1.1",
-        "decimal.js-light": "^2.5.1",
-        "es-toolkit": "^1.39.3",
-        "eventemitter3": "^5.0.1",
-        "immer": "^10.1.1",
-        "react-redux": "8.x.x || 9.x.x",
-        "reselect": "5.1.1",
-        "tiny-invariant": "^1.3.3",
-        "use-sync-external-store": "^1.2.2",
-        "victory-vendor": "^37.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -12200,19 +11935,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
-    },
-    "node_modules/redux-thunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-      "peerDependencies": {
-        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -12274,11 +11996,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -12912,6 +12629,11 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
+      "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A=="
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -13421,7 +13143,8 @@
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -14011,27 +13734,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/victory-vendor": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
-      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {
@@ -14771,6 +14473,19 @@
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
+    },
+    "node_modules/zrender": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
+      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     }
   }
 }

--- a/portal/package.json
+++ b/portal/package.json
@@ -21,6 +21,8 @@
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "lucide-react": "^0.576.0",
     "next": "16.1.7",
     "next-intl": "^4.8.3",
@@ -28,7 +30,6 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "recharts": "^3.7.0",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
@@ -38,13 +39,13 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "jsdom": "^25.0.1",
     "shadcn": "^3.8.5",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "@vitest/coverage-v8": "^3.2.4",
     "typescript": "^5",
     "vitest": "^3.2.4"
   }

--- a/portal/src/app/[locale]/(protected)/dashboard/page.test.tsx
+++ b/portal/src/app/[locale]/(protected)/dashboard/page.test.tsx
@@ -34,6 +34,10 @@ vi.mock("@/lib/api", () => ({
   getDashboardStats: (...args: unknown[]) => mockGetDashboardStats(...args),
 }));
 
+vi.mock("@/components/charts/ThemedECharts", () => ({
+  ThemedECharts: () => <div data-testid="themed-echarts-stub" />,
+}));
+
 describe("DashboardPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/portal/src/app/[locale]/(protected)/dashboard/page.tsx
+++ b/portal/src/app/[locale]/(protected)/dashboard/page.tsx
@@ -4,33 +4,17 @@ import { useAuth } from "@/context/AuthContext";
 import { Link } from "@/i18n/navigation";
 import { useRouter } from "@/i18n/navigation";
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { getDashboardStats, type DashboardStats } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ThemedECharts } from "@/components/charts/ThemedECharts";
+import { useChartTheme } from "@/hooks/use-chart-theme";
 import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  PieChart,
-  Pie,
-  Cell,
-} from "recharts";
-
-const PERIOD_COLORS = ["var(--chart-1)", "var(--chart-2)", "var(--chart-3)"];
-const PIE_COLORS = [
-  "var(--chart-1)",
-  "var(--chart-2)",
-  "var(--chart-3)",
-  "var(--chart-4)",
-  "var(--chart-5)",
-  "var(--chart-3)",
-  "var(--chart-4)",
-];
+  buildPeriodBarOption,
+  buildCourierPieOption,
+  buildCityBarOption,
+} from "@/lib/dashboard-echarts";
 
 export default function DashboardPage() {
   const { user, token, isAuthenticated, isLoading } = useAuth();
@@ -42,6 +26,56 @@ export default function DashboardPage() {
   const [stats, setStats] = useState<DashboardStats | null>(null);
   const [statsError, setStatsError] = useState<string | null>(null);
   const isSuperAdmin = Array.isArray(user?.roles) && user.roles.includes("SuperAdmin");
+  const chartTheme = useChartTheme();
+
+  const themeSlice = useMemo(
+    () => ({
+      border: chartTheme.border,
+      foreground: chartTheme.foreground,
+      mutedForeground: chartTheme.mutedForeground,
+      card: chartTheme.card,
+    }),
+    [chartTheme],
+  );
+
+  const periodChartOption = useMemo(() => {
+    if (!stats) return null;
+    const values = [stats.countToday, stats.countMonth, stats.countYear];
+    if (!values.some((v) => v > 0)) return null;
+    const categories = [tStats("today"), tStats("thisMonth"), tStats("thisYear")];
+    const barColors = [chartTheme.chart[0], chartTheme.chart[1], chartTheme.chart[2]];
+    return buildPeriodBarOption(categories, values, barColors, themeSlice, tStats("bookings"));
+  }, [stats, chartTheme.chart, themeSlice, tStats]);
+
+  const courierChartOption = useMemo(() => {
+    if (!stats?.byCourier.length) return null;
+    return buildCourierPieOption(
+      stats.byCourier,
+      [...chartTheme.chart],
+      themeSlice,
+      tStats("bookings"),
+    );
+  }, [stats, chartTheme.chart, themeSlice, tStats]);
+
+  const fromCitiesOption = useMemo(() => {
+    if (!stats?.fromCities.length) return null;
+    return buildCityBarOption(
+      stats.fromCities.slice(0, 8),
+      chartTheme.chart[0],
+      themeSlice,
+      tStats("bookings"),
+    );
+  }, [stats, chartTheme.chart, themeSlice, tStats]);
+
+  const toCitiesOption = useMemo(() => {
+    if (!stats?.toCities.length) return null;
+    return buildCityBarOption(
+      stats.toCities.slice(0, 8),
+      chartTheme.chart[1],
+      themeSlice,
+      tStats("bookings"),
+    );
+  }, [stats, chartTheme.chart, themeSlice, tStats]);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -55,14 +89,6 @@ export default function DashboardPage() {
   }, [token, isAuthenticated, isLoading, router]);
 
   if (!isAuthenticated || isLoading) return null;
-
-  const periodData = stats
-    ? [
-        { name: tStats("today"), count: stats.countToday, fill: PERIOD_COLORS[0] },
-        { name: tStats("thisMonth"), count: stats.countMonth, fill: PERIOD_COLORS[1] },
-        { name: tStats("thisYear"), count: stats.countYear, fill: PERIOD_COLORS[2] },
-      ]
-    : [];
 
   return (
     <div className="space-y-8">
@@ -103,28 +129,14 @@ export default function DashboardPage() {
                 </div>
               </div>
 
-              {/* Period comparison bar chart */}
-              {periodData.some((d) => d.count > 0) && (
+              {/* Period comparison bar chart (Apache ECharts) */}
+              {periodChartOption && (
                 <div>
                   <h3 className="mb-3 text-sm font-medium text-muted-foreground">
                     {tStats("byPeriod")}
                   </h3>
-                  <div className="h-48 w-full">
-                    <ResponsiveContainer width="100%" height="100%">
-                      <BarChart data={periodData} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
-                        <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                        <XAxis dataKey="name" tick={{ fontSize: 12 }} />
-                        <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
-                        <Tooltip
-                          contentStyle={{
-                            backgroundColor: "var(--card)",
-                            border: "1px solid var(--border)",
-                            borderRadius: "var(--radius)",
-                          }}
-                        />
-                        <Bar dataKey="count" name={tStats("bookings")} radius={[4, 4, 0, 0]} />
-                      </BarChart>
-                    </ResponsiveContainer>
+                  <div className="h-48 w-full min-h-[192px]">
+                    <ThemedECharts option={periodChartOption} height={192} />
                   </div>
                 </div>
               )}
@@ -138,40 +150,11 @@ export default function DashboardPage() {
                   {stats.byCourier.length === 0 ? (
                     <p className="text-sm text-muted-foreground">{tStats("noData")}</p>
                   ) : (
-                    <div className="h-48 w-full">
-                      <ResponsiveContainer width="100%" height="100%">
-                        <PieChart>
-                          <Pie
-                            data={stats.byCourier.map((c, i) => ({
-                              name: c.key,
-                              value: c.count,
-                            }))}
-                            cx="50%"
-                            cy="50%"
-                            innerRadius={40}
-                            outerRadius={64}
-                            paddingAngle={2}
-                            dataKey="value"
-                            nameKey="name"
-                            label={({ name, percent }) =>
-                              `${name} ${((percent ?? 0) * 100).toFixed(0)}%`
-                            }
-                          >
-                            {stats.byCourier.map((_, i) => (
-                              <Cell key={i} fill={PIE_COLORS[i % PIE_COLORS.length]} />
-                            ))}
-                          </Pie>
-                          <Tooltip
-                            formatter={(value: number | undefined) => [value ?? 0, tStats("bookings")]}
-                            contentStyle={{
-                              backgroundColor: "var(--card)",
-                              border: "1px solid var(--border)",
-                              borderRadius: "var(--radius)",
-                            }}
-                          />
-                        </PieChart>
-                      </ResponsiveContainer>
-                    </div>
+                    courierChartOption && (
+                      <div className="h-48 w-full min-h-[192px]">
+                        <ThemedECharts option={courierChartOption} height={192} />
+                      </div>
+                    )
                   )}
                 </div>
                 <div>
@@ -181,32 +164,11 @@ export default function DashboardPage() {
                   {stats.fromCities.length === 0 ? (
                     <p className="text-sm text-muted-foreground">{tStats("noData")}</p>
                   ) : (
-                    <div className="h-48 w-full">
-                      <ResponsiveContainer width="100%" height="100%">
-                        <BarChart
-                          data={stats.fromCities.slice(0, 8)}
-                          layout="vertical"
-                          margin={{ top: 4, right: 8, left: 0, bottom: 4 }}
-                        >
-                          <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                          <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11 }} />
-                          <YAxis
-                            type="category"
-                            dataKey="key"
-                            width={72}
-                            tick={{ fontSize: 11 }}
-                          />
-                          <Tooltip
-                            contentStyle={{
-                              backgroundColor: "var(--card)",
-                              border: "1px solid var(--border)",
-                              borderRadius: "var(--radius)",
-                            }}
-                          />
-                          <Bar dataKey="count" name={tStats("bookings")} fill="var(--chart-1)" radius={[0, 4, 4, 0]} />
-                        </BarChart>
-                      </ResponsiveContainer>
-                    </div>
+                    fromCitiesOption && (
+                      <div className="h-48 w-full min-h-[192px]">
+                        <ThemedECharts option={fromCitiesOption} height={192} />
+                      </div>
+                    )
                   )}
                 </div>
                 <div>
@@ -216,32 +178,11 @@ export default function DashboardPage() {
                   {stats.toCities.length === 0 ? (
                     <p className="text-sm text-muted-foreground">{tStats("noData")}</p>
                   ) : (
-                    <div className="h-48 w-full">
-                      <ResponsiveContainer width="100%" height="100%">
-                        <BarChart
-                          data={stats.toCities.slice(0, 8)}
-                          layout="vertical"
-                          margin={{ top: 4, right: 8, left: 0, bottom: 4 }}
-                        >
-                          <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                          <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11 }} />
-                          <YAxis
-                            type="category"
-                            dataKey="key"
-                            width={72}
-                            tick={{ fontSize: 11 }}
-                          />
-                          <Tooltip
-                            contentStyle={{
-                              backgroundColor: "var(--card)",
-                              border: "1px solid var(--border)",
-                              borderRadius: "var(--radius)",
-                            }}
-                          />
-                          <Bar dataKey="count" name={tStats("bookings")} fill="var(--chart-2)" radius={[0, 4, 4, 0]} />
-                        </BarChart>
-                      </ResponsiveContainer>
-                    </div>
+                    toCitiesOption && (
+                      <div className="h-48 w-full min-h-[192px]">
+                        <ThemedECharts option={toCitiesOption} height={192} />
+                      </div>
+                    )
                   )}
                 </div>
               </div>

--- a/portal/src/components/charts/ThemedECharts.test.tsx
+++ b/portal/src/components/charts/ThemedECharts.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { ThemedECharts } from "./ThemedECharts";
+
+vi.mock("echarts-for-react", () => ({
+  default: function MockEcharts({
+    style,
+    option,
+  }: {
+    style?: React.CSSProperties;
+    option: { series?: unknown };
+  }) {
+    return (
+      <div
+        data-testid="echarts-mock"
+        data-height={style?.height}
+        data-has-series={option?.series != null ? "1" : "0"}
+      />
+    );
+  },
+}));
+
+describe("ThemedECharts", () => {
+  it("renders echarts-for-react with height and option", () => {
+    render(
+      <ThemedECharts
+        option={{ series: [{ type: "bar", data: [1] }] }}
+        height={200}
+      />,
+    );
+    const el = screen.getByTestId("echarts-mock");
+    expect(el).toHaveAttribute("data-height", "200");
+    expect(el).toHaveAttribute("data-has-series", "1");
+  });
+});

--- a/portal/src/components/charts/ThemedECharts.tsx
+++ b/portal/src/components/charts/ThemedECharts.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import ReactEcharts from "echarts-for-react";
+import type { EChartsOption } from "echarts";
+import type { CSSProperties } from "react";
+
+type Props = {
+  option: EChartsOption;
+  className?: string;
+  style?: CSSProperties;
+  /** Default height matches previous dashboard chart rows (h-48). */
+  height?: number;
+};
+
+/**
+ * Apache ECharts with explicit dimensions. Theme colors must be resolved to real values
+ * before passing `option` (see `useChartTheme` + `dashboard-echarts` builders).
+ */
+export function ThemedECharts({ option, className, style, height = 192 }: Props) {
+  return (
+    <ReactEcharts
+      option={option}
+      className={className}
+      style={{ width: "100%", height, ...style }}
+      opts={{ renderer: "canvas" }}
+      notMerge
+      lazyUpdate
+    />
+  );
+}

--- a/portal/src/hooks/use-chart-theme.test.tsx
+++ b/portal/src/hooks/use-chart-theme.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useChartTheme } from "./use-chart-theme";
+
+describe("useChartTheme", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "getComputedStyle").mockImplementation((el: Element) => {
+      if (el === document.documentElement) {
+        return {
+          getPropertyValue: (name: string) => {
+            const map: Record<string, string> = {
+              "--chart-1": "#111111",
+              "--chart-2": "#222222",
+              "--chart-3": "#333333",
+              "--chart-4": "#444444",
+              "--chart-5": "#555555",
+              "--border": "#aaaaaa",
+              "--foreground": "#000000",
+              "--muted-foreground": "#666666",
+              "--background": "#ffffff",
+              "--card": "#eeeeee",
+            };
+            return map[name] ?? "";
+          },
+        } as CSSStyleDeclaration;
+      }
+      return {
+        getPropertyValue: () => "",
+      } as CSSStyleDeclaration;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reads chart CSS variables from the document after mount", async () => {
+    const { result } = renderHook(() => useChartTheme());
+
+    await waitFor(() => {
+      expect(result.current.chart[0]).toBe("#111111");
+    });
+    expect(result.current.border).toBe("#aaaaaa");
+    expect(result.current.card).toBe("#eeeeee");
+  });
+});

--- a/portal/src/hooks/use-chart-theme.ts
+++ b/portal/src/hooks/use-chart-theme.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type ChartTheme = {
+  chart: [string, string, string, string, string];
+  border: string;
+  foreground: string;
+  mutedForeground: string;
+  background: string;
+  card: string;
+};
+
+const FALLBACK: ChartTheme = {
+  chart: ["#888888", "#888888", "#888888", "#888888", "#888888"],
+  border: "#cccccc",
+  foreground: "#000000",
+  mutedForeground: "#666666",
+  background: "#ffffff",
+  card: "#ffffff",
+};
+
+function readTheme(): ChartTheme {
+  const root = document.documentElement;
+  const g = (name: string) => getComputedStyle(root).getPropertyValue(name).trim();
+  const c = (n: string) => g(n) || FALLBACK.chart[0];
+  return {
+    chart: [c("--chart-1"), c("--chart-2"), c("--chart-3"), c("--chart-4"), c("--chart-5")],
+    border: g("--border") || FALLBACK.border,
+    foreground: g("--foreground") || FALLBACK.foreground,
+    mutedForeground: g("--muted-foreground") || FALLBACK.mutedForeground,
+    background: g("--background") || FALLBACK.background,
+    card: g("--card") || FALLBACK.card,
+  };
+}
+
+/**
+ * Reads design-token colors from the document for ECharts (canvas cannot use CSS variables directly).
+ * Updates when the root `class` changes (e.g. dark mode) or on window resize.
+ */
+export function useChartTheme(): ChartTheme {
+  const [theme, setTheme] = useState<ChartTheme>(FALLBACK);
+
+  useEffect(() => {
+    const sync = () => setTheme(readTheme());
+    sync();
+    const el = document.documentElement;
+    const obs = new MutationObserver(sync);
+    obs.observe(el, { attributes: true, attributeFilter: ["class"] });
+    window.addEventListener("resize", sync);
+    return () => {
+      obs.disconnect();
+      window.removeEventListener("resize", sync);
+    };
+  }, []);
+
+  return theme;
+}

--- a/portal/src/lib/dashboard-echarts.test.ts
+++ b/portal/src/lib/dashboard-echarts.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildPeriodBarOption,
+  buildCourierPieOption,
+  buildCityBarOption,
+} from "./dashboard-echarts";
+
+const theme = {
+  border: "#ccc",
+  foreground: "#111",
+  mutedForeground: "#666",
+  card: "#fff",
+};
+
+describe("buildPeriodBarOption", () => {
+  it("maps categories and per-bar colors", () => {
+    const opt = buildPeriodBarOption(
+      ["A", "B"],
+      [3, 7],
+      ["#a00", "#0a0"],
+      theme,
+      "bookings",
+    );
+    const series = opt.series?.[0];
+    expect(series?.type).toBe("bar");
+    const data = series?.data as { value: number; itemStyle: { color: string } }[];
+    expect(data[0].value).toBe(3);
+    expect(data[0].itemStyle.color).toBe("#a00");
+    expect(data[1].value).toBe(7);
+    expect(opt.xAxis).toMatchObject({ type: "category", data: ["A", "B"] });
+  });
+});
+
+describe("buildCourierPieOption", () => {
+  it("builds pie data with colors cycling", () => {
+    const opt = buildCourierPieOption(
+      [
+        { key: "DHL", count: 10 },
+        { key: "Posti", count: 5 },
+      ],
+      ["#c1", "#c2"],
+      theme,
+      "bookings",
+    );
+    const s = opt.series?.[0];
+    expect(s?.type).toBe("pie");
+    const data = s?.data as { name: string; value: number; itemStyle: { color: string } }[];
+    expect(data[0]).toMatchObject({ name: "DHL", value: 10, itemStyle: { color: "#c1" } });
+    expect(data[1]).toMatchObject({ name: "Posti", value: 5, itemStyle: { color: "#c2" } });
+  });
+});
+
+describe("buildCityBarOption", () => {
+  it("uses inverse category axis for horizontal layout", () => {
+    const opt = buildCityBarOption(
+      [
+        { key: "Helsinki", count: 4 },
+        { key: "Tampere", count: 2 },
+      ],
+      "#00f",
+      theme,
+      "bookings",
+    );
+    expect(opt.yAxis).toMatchObject({
+      type: "category",
+      data: ["Helsinki", "Tampere"],
+      inverse: true,
+    });
+    const series = opt.series?.[0];
+    const data = series?.data as { value: number; itemStyle: { color: string } }[];
+    expect(data[0].value).toBe(4);
+    expect(data[0].itemStyle.color).toBe("#00f");
+  });
+});

--- a/portal/src/lib/dashboard-echarts.ts
+++ b/portal/src/lib/dashboard-echarts.ts
@@ -1,0 +1,148 @@
+import type { EChartsOption } from "echarts";
+
+export type ThemeSlice = {
+  border: string;
+  foreground: string;
+  mutedForeground: string;
+  card: string;
+};
+
+/**
+ * Period comparison: vertical bars, one color per category.
+ */
+export function buildPeriodBarOption(
+  categories: string[],
+  values: number[],
+  barColors: string[],
+  theme: ThemeSlice,
+  bookingsLabel: string,
+): EChartsOption {
+  return {
+    grid: { left: 8, right: 8, top: 8, bottom: 8, containLabel: true },
+    tooltip: {
+      trigger: "axis",
+      axisPointer: { type: "shadow" },
+      backgroundColor: theme.card,
+      borderColor: theme.border,
+      borderWidth: 1,
+      textStyle: { color: theme.foreground },
+      valueFormatter: (v) => `${v} ${bookingsLabel}`,
+    },
+    xAxis: {
+      type: "category",
+      data: categories,
+      axisLine: { lineStyle: { color: theme.border } },
+      axisLabel: { color: theme.mutedForeground, fontSize: 12 },
+    },
+    yAxis: {
+      type: "value",
+      minInterval: 1,
+      axisLine: { show: false },
+      axisLabel: { color: theme.mutedForeground, fontSize: 12 },
+      splitLine: { lineStyle: { color: theme.border, opacity: 0.45 } },
+    },
+    series: [
+      {
+        type: "bar",
+        name: bookingsLabel,
+        data: values.map((value, i) => ({
+          value,
+          itemStyle: { color: barColors[i % barColors.length], borderRadius: [4, 4, 0, 0] },
+        })),
+        barMaxWidth: 56,
+      },
+    ],
+  };
+}
+
+export type KeyCount = { key: string; count: number };
+
+/**
+ * Donut: share by courier / carrier.
+ */
+export function buildCourierPieOption(
+  rows: KeyCount[],
+  seriesColors: string[],
+  theme: ThemeSlice,
+  bookingsLabel: string,
+): EChartsOption {
+  return {
+    tooltip: {
+      trigger: "item",
+      backgroundColor: theme.card,
+      borderColor: theme.border,
+      borderWidth: 1,
+      textStyle: { color: theme.foreground },
+      // String formatter avoids strict CallbackDataParams typing; {b} name, {c} value, {d} percent.
+      formatter: "{b}<br/>{c} " + bookingsLabel + " ({d}%)",
+    },
+    series: [
+      {
+        type: "pie",
+        radius: ["40%", "64%"],
+        padAngle: 2,
+        itemStyle: { borderRadius: 4 },
+        label: {
+          color: theme.mutedForeground,
+          formatter: "{b} {d}%",
+        },
+        data: rows.map((r, i) => ({
+          name: r.key,
+          value: r.count,
+          itemStyle: { color: seriesColors[i % seriesColors.length] },
+        })),
+      },
+    ],
+  };
+}
+
+/**
+ * Horizontal bars: top cities (origin or destination).
+ */
+export function buildCityBarOption(
+  rows: KeyCount[],
+  barColor: string,
+  theme: ThemeSlice,
+  bookingsLabel: string,
+): EChartsOption {
+  const keys = rows.map((r) => r.key);
+  const counts = rows.map((r) => r.count);
+  return {
+    grid: { left: 4, right: 8, top: 4, bottom: 4, containLabel: true },
+    tooltip: {
+      trigger: "axis",
+      axisPointer: { type: "shadow" },
+      backgroundColor: theme.card,
+      borderColor: theme.border,
+      borderWidth: 1,
+      textStyle: { color: theme.foreground },
+      valueFormatter: (v) => `${v} ${bookingsLabel}`,
+    },
+    xAxis: {
+      type: "value",
+      minInterval: 1,
+      axisLine: { show: false },
+      axisLabel: { color: theme.mutedForeground, fontSize: 11 },
+      splitLine: { lineStyle: { color: theme.border, opacity: 0.45 } },
+    },
+    yAxis: {
+      type: "category",
+      data: keys,
+      inverse: true,
+      axisLine: { show: false },
+      axisTick: { show: false },
+      axisLabel: { color: theme.mutedForeground, fontSize: 11, width: 72, overflow: "truncate" },
+    },
+    series: [
+      {
+        type: "bar",
+        name: bookingsLabel,
+        data: counts.map((value) => ({
+          value,
+          itemStyle: { color: barColor, borderRadius: [0, 4, 4, 0] },
+        })),
+        barMaxWidth: 22,
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
Replaces Recharts with **Apache ECharts** on the dashboard; theme colors come from CSS variables for light/dark.

## Changes
- Add `echarts`, `echarts-for-react`; remove `recharts`
- `useChartTheme` hook + `ThemedECharts` wrapper
- Pure option builders with unit tests (`dashboard-echarts`)

## Testing
- `npm run test`, `npm run test:coverage`, `npm run build`
- `dotnet test`
