### PR TITLE
chore(docker): restart unless-stopped for compose services

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -77,6 +77,18 @@ Copy `.env.example` to `.env` and change secrets. For Docker, keep `NEXT_PUBLIC_
 docker compose down
 ```
 
+## Restart after reboot
+
+All Compose services use **`restart: unless-stopped`**, so when Docker Desktop starts (for example after you log in on macOS or Windows), containers that were already running are started again automatically. After upgrading to this configuration, recreate the stack once so the policy applies:
+
+```bash
+docker compose up -d
+# or
+docker compose -f docker-compose.one.yml up -d
+```
+
+To keep the stack off across reboots, use `docker compose down` (or stop the containers in Docker Desktop).
+
 ## Data persistence
 
 PostgreSQL data is stored in a Docker volume. Use `docker compose down -v` to remove it.

--- a/docker-compose.one.yml
+++ b/docker-compose.one.yml
@@ -4,6 +4,7 @@
 
 services:
   cargohub:
+    restart: unless-stopped
     image: maleesha404/cargohub:latest
     # Always pull :latest on deploy so GitHub Actions / compose up actually updates the container
     pull_policy: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@
 services:
   db:
     image: postgres:16-alpine
+    restart: unless-stopped
     container_name: cargohub-db
     environment:
       POSTGRES_USER: postgres
@@ -24,6 +25,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    restart: unless-stopped
     container_name: cargohub-api
     environment:
       ASPNETCORE_ENVIRONMENT: Production
@@ -44,6 +46,7 @@ services:
       dockerfile: Dockerfile
       args:
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8080}
+    restart: unless-stopped
     container_name: cargohub-portal
     ports:
       - "3000:3000"


### PR DESCRIPTION
## Summary
Adds `restart: unless-stopped` to all Docker Compose services so the stack comes back when Docker Desktop starts after a host reboot.

## Files
- `docker-compose.yml` — `db`, `api`, `portal`
- `docker-compose.one.yml` — `cargohub`
- `RUN.md` — short section on behavior and running `docker compose up -d` once after pull

## Note
Recreate containers once after merge: `docker compose up -d` (or `docker compose -f docker-compose.one.yml up -d`).
