### PR TITLE
fix(docker): ngrok dashboard on host :14040 (avoid :4040 bind conflict)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,8 @@ Cors__PortalOrigin=http://localhost:3000
 # Self-hosted Docker: ~/.cargohub.env or GitHub Secrets — compose maps CORS__PORTAL_ORIGIN → Cors__PortalOrigin
 # GitHub Actions / docker-compose.one: NGROK_AUTHTOKEN — ngrok agent runs *inside* the all-in-one image (tunnel to :8888)
 # NGROK_AUTHTOKEN=your_token_here
+# CI only: if you change the compose host port for ngrok’s web UI, set the tunnels API URL (default matches 14040:4040)
+# NGROK_LOCAL_API_URL=http://127.0.0.1:14040/api/tunnels
 # For multiple origins use indexed keys:
 # Cors__PortalOrigins__0=http://localhost:3000
 # Cors__PortalOrigins__1=https://your-portal.vercel.app

--- a/.github/workflows/docker-deploy-mac.yml
+++ b/.github/workflows/docker-deploy-mac.yml
@@ -69,12 +69,12 @@ jobs:
             echo "::warning::DOCKERHUB_* missing for login"
           fi
 
-      - name: Stop stack & free ports (8888, 8080, 3000, 4040)
+      - name: Stop stack & free ports (8888, 8080, 3000, 14040)
         run: |
           set -e
           $COMPOSE_CMD down --remove-orphans 2>/dev/null || true
           docker rm -f cargohub 2>/dev/null || true
-          for port in 8888 8080 3000 4040; do
+          for port in 8888 8080 3000 14040; do
             for id in $(docker ps -q --filter "publish=$port" 2>/dev/null); do
               docker rm -f "$id" || true
             done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ npm run dev      # In portal/ directory for UI
 
 - **CI:** `docker-build-push.yml` (Ubuntu build/push) → `docker-deploy-mac.yml` (`workflow_run`, self-hosted deploy — avoids queue deadlocks on one Mac runner).
 - **Image:** `Dockerfile.all-in-one` — PostgreSQL + API + Next.js + **nginx** on **`:8888`** (single public entry: UI + `/api`).
-- **ngrok:** `ngrok.yml` tunnels **one** address — **`:8888`** (not separate 3000/8080). Dashboard on host **`:4040`**.
+- **ngrok:** `ngrok.yml` tunnels **one** address — **`:8888`** (not separate 3000/8080). In-container ngrok web UI is **`:4040`**; compose maps host **`:14040`** → **`:4040`** to avoid clashing with host ngrok on **`:4040`**.
 - **Portal API URL:** Production image builds with `NEXT_PUBLIC_API_URL=__SAME_ORIGIN__`; `portal/src/lib/api.ts` uses `window.location.origin` in the browser so API calls match the ngrok URL.
 - **CORS:** Set `Cors__PortalOrigin` / `CORS__PORTAL_ORIGIN` to the **HTTPS ngrok origin** (same as the public URL) when testing from the internet.
 - **Routes:** Portal uses locale prefixes — e.g. **`/en/login`**, **`/en/dashboard`** — not bare `/dashboard`.

--- a/Dockerfile.all-in-one
+++ b/Dockerfile.all-in-one
@@ -1,5 +1,5 @@
 # All-in-one: PostgreSQL + API + Portal in a single image
-# Run (include 8888 for nginx = one public URL with ngrok): docker run -p 8888:8888 -p 3000:3000 -p 8080:8080 -p 4040:4040 -v cargohub_data:/var/lib/postgresql/data maleesha404/cargohub:latest
+# Run (include 8888 for nginx = one public URL with ngrok): docker run -p 8888:8888 -p 3000:3000 -p 8080:8080 -p 14040:4040 -v cargohub_data:/var/lib/postgresql/data maleesha404/cargohub:latest
 
 # ---- Build API ----
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS api-build

--- a/RUN.md
+++ b/RUN.md
@@ -10,13 +10,13 @@ Single image with db + API + portal:
 
 ```bash
 docker pull maleesha404/cargohub:latest
-docker run -d -p 8888:8888 -p 3000:3000 -p 8080:8080 -p 4040:4040 -v cargohub_data:/var/lib/postgresql/data --name cargohub maleesha404/cargohub:latest
+docker run -d -p 8888:8888 -p 3000:3000 -p 8080:8080 -p 14040:4040 -v cargohub_data:/var/lib/postgresql/data --name cargohub maleesha404/cargohub:latest
 ```
 
 - **`:8888`** — **nginx**: same origin for UI + API (what you should expose behind **one** ngrok tunnel). Example: `https://<subdomain>.ngrok-free.app/en/` and API at `.../api/v1/...`.
 - **`:3000` / `:8080`** — direct Next.js / API (debug or local-only).
 
-**Public URLs (ngrok inside the image):** set `-e NGROK_AUTHTOKEN=your_token` on `docker run` (or use `docker-compose.one.yml`). The image includes the ngrok agent; tunnels start automatically. **`ngrok.yml` tunnels port `8888` (nginx)** so one HTTPS URL serves the portal and `/api`. **`ngrok.yml` uses `web_addr: 0.0.0.0:4040`** so the host can reach the ngrok API on **http://localhost:4040**. You do **not** need ngrok installed on the host. If URLs are empty in CI, **pull the latest image** (older images may not include in-container ngrok).
+**Public URLs (ngrok inside the image):** set `-e NGROK_AUTHTOKEN=your_token` on `docker run` (or use `docker-compose.one.yml`). The image includes the ngrok agent; tunnels start automatically. **`ngrok.yml` tunnels port `8888` (nginx)** so one HTTPS URL serves the portal and `/api`. Inside the container, ngrok’s web API listens on **`:4040`**; map it to **`14040` on the host** (e.g. `-p 14040:4040`) so you can open **http://localhost:14040** without colliding with a **standalone ngrok on the host** (which often uses `:4040`). You do **not** need ngrok installed on the host. If URLs are empty in CI, **pull the latest image** (older images may not include in-container ngrok).
 
 **Paths:** The portal uses **locale-prefixed routes** (e.g. **`/en/login`**, **`/en/dashboard`**). **`/dashboard` alone returns 404** — use **`/en/dashboard`** (or your default locale).
 
@@ -31,7 +31,7 @@ docker compose -f docker-compose.one.yml up -d
 - **Public (nginx, same as ngrok):** http://localhost:8888  
 - **Portal (direct):** http://localhost:3000  
 - **API (direct):** http://localhost:8080  
-- **ngrok dashboard (if token set):** http://localhost:4040  
+- **ngrok dashboard (if token set):** http://localhost:14040 (mapped from container `:4040`)  
 
 ---
 
@@ -117,7 +117,7 @@ When **PR Validation** or **Docker build / Mac deploy** fails, a workflow may op
 |------|----------------|----------------|
 | 1. Build & push | GitHub (Ubuntu) | Builds `Dockerfile.all-in-one`, pushes `cargohub:latest` + `:sha` to Docker Hub |
 | 2. Deploy on Mac | Your self-hosted runner | `docker compose pull` + `up -d --force-recreate`, smoke tests |
-| 3. ngrok | **Inside the container** | If `NGROK_AUTHTOKEN` is set (GitHub secret), ngrok starts in the image; use **http://localhost:4040** on the Mac for public URLs (no ngrok binary on the host required) |
+| 3. ngrok | **Inside the container** | If `NGROK_AUTHTOKEN` is set (GitHub secret), ngrok starts in the image; use **http://localhost:14040** on the Mac for the ngrok dashboard (no ngrok binary on the host required) |
 
 **Secrets:** `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` (required). Optional: `NGROK_AUTHTOKEN`, `CORS__PORTAL_ORIGIN`, `BOOTSTRAP__SECRET`, `JWT__SIGNING_KEY`.
 
@@ -144,7 +144,7 @@ When **PR Validation** or **Docker build / Mac deploy** fails, a workflow may op
 
 3. **Secrets:** `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` (required). **`NGROK_AUTHTOKEN`** — [ngrok dashboard](https://dashboard.ngrok.com/get-started/your-authtoken); add as repo secret. Optional: `BOOTSTRAP__SECRET`, `JWT__SIGNING_KEY`, `CORS__PORTAL_ORIGIN`.
 
-4. **Public URLs:** On the Mac, open **http://localhost:4040** (mapped from the container) for the ngrok UI and **`public_url`** list. Or read the **Show ngrok public URLs** step in the Actions run.
+4. **Public URLs:** On the Mac, open **http://localhost:14040** (mapped from container `:4040`) for the ngrok UI and **`public_url`** list. Or read the **Show ngrok public URLs** step in the Actions run.
 
 5. **Local env (optional):** `~/.cargohub.env` on the Mac for extra compose vars.
 
@@ -216,9 +216,14 @@ docker rm -f cargohub 2>/dev/null || true
 docker ps -q --filter publish=8888 | xargs -r docker rm -f
 docker ps -q --filter publish=8080 | xargs -r docker rm -f
 docker ps -q --filter publish=3000 | xargs -r docker rm -f
+docker ps -q --filter publish=14040 | xargs -r docker rm -f
 ```
 
 Then run the workflow again or `docker compose -f docker-compose.one.yml up -d`.
+
+### `failed to bind host port` for **4040** or **14040** (`address already in use`)
+
+The stack maps the **in-container** ngrok web UI (**`:4040`**) to **`:14040` on the host** so it does not fight with a **standalone ngrok** on the Mac (often **`:4040`**). Open **http://localhost:14040** for the dashboard. If **14040** is still busy, free it with the `publish=14040` line above or change the port in `docker-compose.one.yml` and set **`NGROK_LOCAL_API_URL`** for CI scripts (see `scripts/wait-ngrok-tunnels.py`).
 
 ### `docker compose pull` / `auth.docker.io` timeout on the Mac
 
@@ -249,7 +254,7 @@ They are **not contradictory**:
 
 **Common causes**
 
-1. **Old URL** — On **ngrok free**, each time the in-container ngrok agent **restarts**, you often get a **new** random subdomain. A bookmark to **`merle-…-palma.ngrok-free.dev`** stays dead after the tunnel moved. **Open the current URL** from the runner: **http://localhost:4040** (ngrok API; port mapped in `docker-compose.one.yml`).
+1. **Old URL** — On **ngrok free**, each time the in-container ngrok agent **restarts**, you often get a **new** random subdomain. A bookmark to **`merle-…-palma.ngrok-free.dev`** stays dead after the tunnel moved. **Open the current URL** from the runner: **http://localhost:14040** (ngrok API; host port in `docker-compose.one.yml`).
 2. **No token** — If **`NGROK_AUTHTOKEN`** is not set for the container, ngrok may not start; localhost still works, public URL never comes up.
 3. **ngrok crashed** after deploy — Check **`docker logs cargohub`** (look for ngrok) and restart: `docker compose -f docker-compose.one.yml up -d --force-recreate`.
 4. **CORS** — After the URL changes, update **`CORS__PORTAL_ORIGIN`** (compose / `~/.cargohub.env`) to the **new** `https://…` origin.

--- a/docker-compose.one.yml
+++ b/docker-compose.one.yml
@@ -13,8 +13,9 @@ services:
       - "8888:8888"
       - "3000:3000"
       - "8080:8080"
-      # ngrok local API / dashboard (only when NGROK_AUTHTOKEN is set — see Dockerfile.all-in-one)
-      - "4040:4040"
+      # ngrok local API / dashboard inside container is :4040; map to 14040 on host to avoid
+      # "address already in use" when host ngrok or another tool already binds :4040.
+      - "14040:4040"
     volumes:
       - cargohub_data:/var/lib/postgresql/data
     environment:

--- a/scripts/show-ngrok-public-urls.py
+++ b/scripts/show-ngrok-public-urls.py
@@ -41,7 +41,7 @@ def main():
         print("  Troubleshooting:")
         print("  - Image must include ngrok (Dockerfile.all-in-one) — pull latest :latest")
         print("  - NGROK_AUTHTOKEN must be passed into the container (compose env / GitHub secret)")
-        print("  - ngrok.yml uses web_addr: 0.0.0.0:4040 so the host can reach the API")
+        print("  - ngrok listens on :4040 inside the container; compose maps host :14040 -> :4040")
         print("  - Check: docker logs cargohub 2>&1 | tail -80")
         print("  - Check: docker exec cargohub tail -50 /tmp/ngrok.log")
 
@@ -63,8 +63,8 @@ def main():
             )
         body = (
             "## Public URLs (remote access)\n\n"
-            "Open these from **any browser** (internet). On the Mac: **http://localhost:4040** "
-            "for the ngrok dashboard.\n\n"
+            "Open these from **any browser** (internet). On the Mac: **http://localhost:14040** "
+            "for the ngrok dashboard (mapped from container :4040).\n\n"
             f"{tip}"
             "| Service | URL |\n"
             "|---------|-----|\n"

--- a/scripts/wait-ngrok-tunnels.py
+++ b/scripts/wait-ngrok-tunnels.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 """Poll ngrok /api/tunnels until at least one tunnel exists or timeout. Prints final JSON to stdout."""
 import json
+import os
 import sys
 import time
 import urllib.error
 import urllib.request
 
-URL = "http://127.0.0.1:4040/api/tunnels"
+# Host port must match docker-compose.one.yml (14040 -> container 4040).
+_DEFAULT_TUNNELS = "http://127.0.0.1:14040/api/tunnels"
+URL = os.environ.get("NGROK_LOCAL_API_URL", _DEFAULT_TUNNELS)
 # Total wait up to ~2 minutes (60 * 2s)
 ATTEMPTS = 60
 INTERVAL = 2.0


### PR DESCRIPTION
## Problem
Mac deploy failed: \ailed to bind host port for 0.0.0.0:4040 ... address already in use\ — often because standalone ngrok (or another process) already uses **:4040** on the host.

## Change
- Map **\14040:4040\** in \docker-compose.one.yml\ (in-container ngrok still listens on **:4040**).
- \scripts/wait-ngrok-tunnels.py\ defaults to \http://127.0.0.1:14040/api/tunnels\; override with \NGROK_LOCAL_API_URL\ if needed.
- CI \Stop stack & free ports\ includes **14040** instead of 4040.
- Docs (\RUN.md\, \CLAUDE.md\, \Dockerfile.all-in-one\ comment, \.env.example\) updated.

## After merge
Redeploy; open ngrok dashboard at **http://localhost:14040** on the Mac.