### PR TITLE
docs(ci): sectioned workflows + workflow index README

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,56 @@
+# GitHub Actions workflows
+
+This folder is split by **concern**. Each YAML file is one workflow (one entry in the Actions tab).
+
+## Overview
+
+```mermaid
+flowchart LR
+  subgraph pr[Pull requests]
+    PR[PR Validation]
+    DV[Docker validate]
+  end
+  subgraph push[Push to main / master / development]
+    BP[Docker build and push]
+    DM[Docker deploy on Mac]
+  end
+  PR --> Portal[Portal CI]
+  PR --> Back[Backend CI]
+  Portal --> Gates[Coverage gates]
+  Back --> Gates
+  BP -.trigger.-> DM
+```
+
+| Workflow file | When it runs | Purpose |
+|---------------|----------------|---------|
+| [`pr-validation.yml`](./pr-validation.yml) | PRs to `main` / `master` / `development` | Portal tests → backend tests → coverage gates (75%) → optional issue on failure |
+| [`docker-validate.yml`](./docker-validate.yml) | Same PRs | Builds `Dockerfile.all-in-one` only (no push) |
+| [`docker-build-push.yml`](./docker-build-push.yml) | Push to `main` / `master` / `development` | Build & push `cargohub` image to Docker Hub |
+| [`docker-deploy-mac.yml`](./docker-deploy-mac.yml) | After **Docker — build & push** succeeds | Self-hosted Mac: pull, compose up, smoke tests, ngrok URLs |
+| [`deploy-example.yml`](./deploy-example.yml) | Manual | Example / template |
+| [`add-copilot-reviewer.yml`](./add-copilot-reviewer.yml) | As configured | Copilot reviewer automation |
+
+## PR Validation — job order
+
+1. **Portal** — `npm ci`, Vitest + coverage, upload artifact  
+2. **Backend** — `dotnet` test + coverage, upload artifacts  
+3. **Coverage gates** — merge thresholds (75% line & branch)  
+4. **Notify** — open issue if a job failed (not on forks)
+
+## Docker — deploy on Mac — step groups
+
+The Mac workflow is **one job** (must stay on the same machine as Docker). Steps are grouped in the YAML as:
+
+1. **Trigger & repo** — context, checkout at build SHA  
+2. **Registry & host prep** — compose env, Docker Hub login, stop old stack / free ports  
+3. **Image & stack** — `compose pull` (retry), `compose up`  
+4. **Smoke checks** — API :8080, portal :3000, nginx :8888  
+5. **Report** — job summary, optional ngrok public URLs  
+
+Failure notification runs as a **separate job** (`notify-deploy-failure`) on GitHub-hosted Ubuntu so issues still open if the Mac job fails.
+
+## Trigger chain (Docker)
+
+`docker-build-push.yml` completes → `workflow_run` fires → `docker-deploy-mac.yml` runs **only** if the build succeeded and the branch is `main`, `master`, or `development`.
+
+The **workflow name** `Docker — build & push image` must stay in sync with `workflows:` in `docker-deploy-mac.yml`.

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,5 +1,9 @@
 # Part 1 of 2: build & push only (Ubuntu). Fast; duplicate runs on same branch cancel.
 # Part 2: docker-deploy-mac.yml runs on the self-hosted runner after this workflow succeeds.
+#
+# Jobs:
+#   1. build-image        — Dockerfile.all-in-one → Docker Hub
+#   2. notify-build-failure — issue if build fails (Ubuntu; always runs after job 1)
 
 name: Docker — build & push image
 
@@ -13,6 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ─── Build & push (Ubuntu) ───
   build-image:
     name: Build & push image
     runs-on: ubuntu-latest
@@ -56,6 +61,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # ─── Notify (only if build failed) ───
   notify-build-failure:
     name: Open issue on build failure
     needs: [build-image]

--- a/.github/workflows/docker-deploy-mac.yml
+++ b/.github/workflows/docker-deploy-mac.yml
@@ -2,6 +2,14 @@
 # Avoids queueing full pipelines on a single self-hosted runner (no build+deploy pile-up).
 #
 # workflow_run: requires this file on the default branch. Triggering workflow name must match exactly.
+#
+# Sections (single job = same machine as Docker; see .github/workflows/README.md):
+#   §1 Trigger & checkout
+#   §2 Compose env & registry login
+#   §3 Stop old stack & pull image
+#   §4 Start stack (compose up)
+#   §5 Smoke tests
+#   §6 Deploy summary & ngrok URLs
 
 name: Docker — deploy on Mac
 
@@ -33,7 +41,8 @@ jobs:
       TRIGGER_BRANCH: ${{ github.event.workflow_run.head_branch }}
 
     steps:
-      - name: Print trigger context
+      # ----- §1 Trigger & checkout -----
+      - name: "§1 · Print trigger context"
         run: |
           set -e
           echo "=== Triggered by successful build ==="
@@ -43,12 +52,13 @@ jobs:
           echo "hostname=$(hostname 2>/dev/null || echo n/a)"
           uname -a 2>/dev/null || true
 
-      - name: Checkout repository (same commit as build)
+      - name: "§1 · Checkout repository (same commit as build)"
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 
-      - name: Set Compose command (optional ~/.cargohub.env)
+      # ----- §2 Compose env & registry -----
+      - name: "§2 · Set Compose command (optional ~/.cargohub.env)"
         run: |
           set -e
           if [ -f "$HOME/.cargohub.env" ]; then
@@ -57,7 +67,7 @@ jobs:
             echo "COMPOSE_CMD=docker compose -f docker-compose.one.yml" >> "$GITHUB_ENV"
           fi
 
-      - name: Log in to Docker Hub (authenticated pull)
+      - name: "§2 · Log in to Docker Hub (authenticated pull)"
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -69,7 +79,8 @@ jobs:
             echo "::warning::DOCKERHUB_* missing for login"
           fi
 
-      - name: Stop stack & free ports (8888, 8080, 3000, 14040)
+      # ----- §3 Clean host & pull image -----
+      - name: "§3 · Stop stack & free ports (8888, 8080, 3000, 14040)"
         run: |
           set -e
           $COMPOSE_CMD down --remove-orphans 2>/dev/null || true
@@ -80,7 +91,7 @@ jobs:
             done
           done
 
-      - name: Pull image (retry)
+      - name: "§3 · Pull image (retry)"
         run: |
           set -e
           export COMPOSE_HTTP_TIMEOUT="${COMPOSE_HTTP_TIMEOUT:-600}"
@@ -94,7 +105,8 @@ jobs:
             n=$((n+1))
           done
 
-      - name: Start stack (compose up)
+      # ----- §4 Start stack -----
+      - name: "§4 · Start stack (compose up)"
         env:
           Bootstrap__Secret: ${{ secrets.BOOTSTRAP__SECRET }}
           Jwt__SigningKey: ${{ secrets.JWT__SIGNING_KEY }}
@@ -105,29 +117,31 @@ jobs:
           export COMPOSE_HTTP_TIMEOUT="${COMPOSE_HTTP_TIMEOUT:-600}"
           $COMPOSE_CMD up -d --force-recreate --remove-orphans
 
-      - name: Prune dangling images
+      - name: "§4 · Prune dangling images"
         run: docker image prune -f || true
 
-      - name: Wait for stack boot
+      - name: "§4 · Wait for stack boot"
         run: sleep 25
 
-      - name: Smoke — API :8080
+      # ----- §5 Smoke tests -----
+      - name: "§5 · Smoke — API :8080"
         run: |
           set -e
           curl -sfS --retry 25 --retry-delay 5 --retry-all-errors "http://localhost:8080/api/v1/health_"
 
-      - name: Smoke — Portal :3000
+      - name: "§5 · Smoke — Portal :3000"
         run: |
           set -e
           curl -sfS --retry 25 --retry-delay 5 --retry-all-errors -o /dev/null "http://localhost:3000/"
 
-      - name: Smoke — nginx :8888
+      - name: "§5 · Smoke — nginx :8888"
         run: |
           set -e
           curl -sfS --retry 25 --retry-delay 5 --retry-all-errors "http://localhost:8888/api/v1/health_"
           curl -sfS --retry 25 --retry-delay 5 --retry-all-errors -o /dev/null "http://localhost:8888/en/"
 
-      - name: Set IMAGE_DIGEST for summary
+      # ----- §6 Report -----
+      - name: "§6 · Set IMAGE_DIGEST for summary"
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         run: |
@@ -135,10 +149,10 @@ jobs:
           DIG=$(docker inspect --format='{{index .RepoDigests 0}}' "$IMG" 2>/dev/null || echo "")
           echo "IMAGE_DIGEST=$DIG" >> "$GITHUB_ENV"
 
-      - name: Write deployment report (Job Summary)
+      - name: "§6 · Write deployment report (Job Summary)"
         run: chmod +x scripts/ci/deploy-summary.sh 2>/dev/null; sh scripts/ci/deploy-summary.sh
 
-      - name: Show public ngrok URLs
+      - name: "§6 · Show public ngrok URLs"
         continue-on-error: true
         env:
           NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
@@ -147,6 +161,7 @@ jobs:
           TUNNELS=$(python3 scripts/wait-ngrok-tunnels.py)
           echo "$TUNNELS" | python3 scripts/show-ngrok-public-urls.py
 
+  # Separate job: GitHub-hosted (issues API); runs if deploy-mac failed
   notify-deploy-failure:
     name: Open issue on deploy failure
     needs: [deploy-mac]

--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -1,5 +1,7 @@
 # Verifies Dockerfile.all-in-one builds (no registry push).
 # Run automatically on PRs; run manually: Actions → Docker validate (all-in-one) → Run workflow.
+#
+# Single job: build (no push) — see .github/workflows/README.md
 
 name: Docker validate (all-in-one)
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,8 +1,10 @@
-# Single responsibility per job:
+# ─────────────────────────────────────────────────────────────────────────────
+# PR Validation — four independent jobs (parallel where possible)
 #   1. portal-ci      — Node, Vitest, portal coverage artifact
 #   2. backend-ci     — .NET build/test, backend coverage artifact
 #   3. coverage-gates — download both artifacts, summary + 75% enforcement
 #   4. notify-pr-failure — issue on fork-safe branches only
+# ─────────────────────────────────────────────────────────────────────────────
 
 name: PR Validation
 
@@ -12,6 +14,7 @@ on:
   workflow_dispatch:
 
 jobs:
+  # ─── 1 · Portal (parallel with backend-ci) ───
   portal-ci:
     name: 1 — Portal (Vitest + coverage)
     runs-on: ubuntu-latest
@@ -37,6 +40,7 @@ jobs:
           path: portal/coverage/
           retention-days: 14
 
+  # ─── 2 · Backend (parallel with portal-ci) ───
   backend-ci:
     name: 2 — Backend (.NET + coverage)
     runs-on: ubuntu-latest
@@ -86,6 +90,7 @@ jobs:
           path: CoverageReport/
           retention-days: 14
 
+  # ─── 3 · Coverage gates (after portal + backend) ───
   coverage-gates:
     name: 3 — Coverage thresholds (75%)
     needs: [portal-ci, backend-ci]
@@ -97,6 +102,7 @@ jobs:
       - name: Install jq and bc
         run: sudo apt-get update -qq && sudo apt-get install -y -qq jq bc
 
+      # --- Download artifacts from portal-ci + backend-ci ---
       - name: Download portal coverage
         uses: actions/download-artifact@v4
         with:
@@ -109,6 +115,7 @@ jobs:
           name: backend-testresults
           path: TestResults
 
+      # --- Summary table in GitHub Step Summary ---
       - name: Coverage summary (Job Summary)
         run: |
           COV_FILE=$(find ./TestResults -name "coverage.cobertura.xml" -print -quit 2>/dev/null)
@@ -144,6 +151,7 @@ jobs:
             echo "**Artifacts:** Backend HTML: **coverage-report** | Portal: **portal-coverage**"
           } | tee -a "$GITHUB_STEP_SUMMARY"
 
+      # --- Fail the job if either stack is below 75% ---
       - name: Enforce backend coverage (75% line & branch)
         run: |
           COV_FILE=$(find ./TestResults -name "coverage.cobertura.xml" -print -quit 2>/dev/null)
@@ -185,6 +193,7 @@ jobs:
           fi
           if [ $FAIL -eq 1 ]; then exit 1; fi
 
+  # ─── 4 · Notify (runs on failure if not a fork) ───
   notify-pr-failure:
     name: 4 — Open issue on failure
     needs: [portal-ci, backend-ci, coverage-gates]

--- a/RUN.md
+++ b/RUN.md
@@ -99,6 +99,8 @@ PostgreSQL data is stored in a Docker volume. Use `docker compose down -v` to re
 
 ### Pipeline layout (single responsibility)
 
+See **`.github/workflows/README.md`** for a full index of workflow files, triggers, and how the Mac deploy job is split into step sections (§1–§6).
+
 | Workflow | Jobs | Purpose |
 |----------|------|--------|
 | **Docker — build & push image** | Build & push on Ubuntu; optional issue on build failure | Runs on **every** push; **duplicate builds on the same branch cancel** so the registry always gets the latest commit quickly. |


### PR DESCRIPTION
## Summary
- New **\.github/workflows/README.md\**: table of all workflows, trigger chain, PR Validation job order, Mac deploy step groups (§1–§6), mermaid overview.
- **Docker — deploy on Mac**: step names prefixed (\§1 ·\ … \§6 ·\) and YAML comment blocks so logs map to phases without splitting the job (must stay one self-hosted job for Docker).
- **PR Validation** / **Docker build & push** / **Docker validate**: clearer job/step comments.
- **RUN.md**: link to the workflow README under the pipeline section.

No behavior change to CI logic.