### PR TITLE
fix(portal): full viewport width for protected UI

### DIFF
--- a/portal/src/app/[locale]/(protected)/layout.tsx
+++ b/portal/src/app/[locale]/(protected)/layout.tsx
@@ -34,9 +34,14 @@ export default function ProtectedLayout({
   }
 
   return (
-    <div data-slot="layout" className="min-h-screen bg-background">
+    <div data-slot="layout" className="flex min-h-screen flex-col bg-background">
       <Navbar />
-      <main data-slot="main" className="container py-6 px-4">{children}</main>
+      <main
+        data-slot="main"
+        className="w-full flex-1 px-4 py-6 sm:px-6 lg:px-8"
+      >
+        {children}
+      </main>
     </div>
   );
 }

--- a/portal/src/app/layout.tsx
+++ b/portal/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
     <html lang="en" data-theme="minimalism" suppressHydrationWarning>
       <body
         data-slot="body"
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}
+        className={`${geistSans.variable} ${geistMono.variable} min-h-screen w-full antialiased bg-background text-foreground`}
         suppressHydrationWarning
       >
         {children}

--- a/portal/src/components/Navbar.tsx
+++ b/portal/src/components/Navbar.tsx
@@ -61,7 +61,7 @@ export function Navbar() {
 
   return (
     <header data-slot="navbar" className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="container flex h-14 items-center justify-between px-4">
+      <div className="flex h-14 w-full items-center justify-between px-4 sm:px-6 lg:px-8">
         <Link href="/dashboard" className="flex items-center gap-2 font-semibold">
           {branding.logoUrl ? (
             <img src={branding.logoUrl} alt="" className="h-8 w-auto object-contain" />


### PR DESCRIPTION
## Summary
- Remove Tailwind \container\ from protected \<main>\ and navbar inner wrapper so content uses the full window width with consistent horizontal padding (\px-4 sm:px-6 lg:px-8\).
- Use \lex min-h-screen flex-col\ with \main\ as \lex-1\ so the shell fills the viewport vertically.
- Add \min-h-screen w-full\ on \ody\ for a reliable full-viewport root.

## Testing
- \
pm run test -- --run\ in \portal/\ (156 tests passed).

Refs: layout alignment / not full-screen issue on dashboard and other protected pages.

Made with [Cursor](https://cursor.com)