### PR TITLE
fix(docker): copy .npmrc before npm ci (ERESOLVE in CI)

### DIFF
--- a/Dockerfile.all-in-one
+++ b/Dockerfile.all-in-one
@@ -21,7 +21,8 @@ ARG BUILD_REF=local
 ENV NEXT_PUBLIC_BUILD_REF=$BUILD_REF
 # Same-origin API via nginx + single ngrok URL (browser uses window.location.origin)
 ENV NEXT_PUBLIC_API_URL=__SAME_ORIGIN__
-COPY portal/package.json portal/package-lock.json* ./
+# .npmrc (e.g. legacy-peer-deps) must be present before npm ci — same as local portal installs
+COPY portal/package.json portal/package-lock.json* portal/.npmrc ./
 RUN npm ci
 COPY portal/ .
 RUN npm run build

--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 ARG NEXT_PUBLIC_API_URL=http://localhost:8080
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 
-COPY package.json package-lock.json* ./
+COPY package.json package-lock.json* .npmrc ./
 RUN npm ci
 
 COPY . .


### PR DESCRIPTION
## Problem
**Docker — build & push image** failed on \
pm ci\ with \ERESOLVE\: \echarts-wordcloud@2.1.0\ peers \echarts@^5.0.1\ while the app uses \echarts@^6\.

## Root cause
\portal/.npmrc\ sets \legacy-peer-deps=true\ (so local and \cd portal && npm ci\ in PR validation work), but **Dockerfile.all-in-one** only copied \package.json\ and \package-lock.json\ before \
pm ci\, so npm never read \.npmrc\.

## Fix
- **Dockerfile.all-in-one**: \COPY\ \portal/.npmrc\ together with package files before \
pm ci\.
- **portal/Dockerfile**: same pattern for consistency.

## Refs
CI log: \
pm ci\ exit 1, peer dependency conflict on echarts.

Made with [Cursor](https://cursor.com)