### PR TITLE
fix(portal): import bookingsImportPreview (Docker build)

### DIFF
--- a/portal/src/app/[locale]/(protected)/bookings/page.tsx
+++ b/portal/src/app/[locale]/(protected)/bookings/page.tsx
@@ -11,6 +11,7 @@ import {
   bookingsImportAnalyze,
   bookingsImportApplyMapping,
   bookingsImportConfirm,
+  bookingsImportPreview,
   bookingsWaybillsBulkDownload,
   draftList,
   type BookingImportPreview,


### PR DESCRIPTION
Fixes Next.js build: Cannot find name bookingsImportPreview in bookings/page.tsx. Add missing import from @/lib/api. Verified: npm run build, npm run test.

Made with [Cursor](https://cursor.com)