### PR TITLE
test(portal): coverage above 75% (fix PR validation)

### DIFF
--- a/portal/src/app/[locale]/(protected)/bookings/page.test.tsx
+++ b/portal/src/app/[locale]/(protected)/bookings/page.test.tsx
@@ -27,11 +27,17 @@ vi.mock("@/lib/api", () => ({
   bookingsImportAnalyze: vi.fn(),
   bookingsImportApplyMapping: vi.fn(),
   bookingsImportConfirm: vi.fn(),
+  bookingsImportPreview: vi.fn(),
   bookingsWaybillsBulkDownload: vi.fn(),
 }));
 
 const bookingList = await import("@/lib/api").then((m) => m.bookingList);
 const draftList = await import("@/lib/api").then((m) => m.draftList);
+const bookingsImportPreview = await import("@/lib/api").then((m) => m.bookingsImportPreview);
+const bookingsImportConfirm = await import("@/lib/api").then((m) => m.bookingsImportConfirm);
+const bookingsWaybillsBulkDownload = await import("@/lib/api").then(
+  (m) => m.bookingsWaybillsBulkDownload,
+);
 
 describe("BookingsPage", () => {
   beforeEach(() => {
@@ -222,5 +228,122 @@ describe("BookingsPage", () => {
     ]);
     render(<BookingsPage />);
     await expect(screen.findByText("—")).resolves.toBeInTheDocument();
+  });
+
+  it("import with zero data rows sets importNoDataRows error", async () => {
+    vi.mocked(bookingsImportPreview).mockResolvedValue({
+      sessionId: "s0",
+      completedCount: 0,
+      draftCount: 0,
+      skippedEmptyRows: 0,
+      totalDataRows: 0,
+    });
+    render(<BookingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [new File(["h"], "t.csv", { type: "text/csv" })] } });
+    await vi.waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("importNoDataRows");
+    });
+  });
+
+  it("import preview failure shows error on alert", async () => {
+    vi.mocked(bookingsImportPreview).mockRejectedValue(new Error("preview failed"));
+    render(<BookingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [new File(["h"], "t.csv")] } });
+    await vi.waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("preview failed");
+    });
+  });
+
+  it("import opens dialog and can confirm completed rows", async () => {
+    vi.mocked(bookingsImportPreview).mockResolvedValue({
+      sessionId: "s1",
+      completedCount: 1,
+      draftCount: 0,
+      skippedEmptyRows: 0,
+      totalDataRows: 1,
+    });
+    vi.mocked(bookingsImportConfirm).mockResolvedValue({
+      createdCount: 1,
+      draftCount: 0,
+      errors: [],
+      createdBookingIds: ["bid1"],
+      draftBookingIds: [],
+    });
+    render(<BookingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [new File(["h"], "t.csv")] } });
+    await expect(screen.findByRole("dialog")).resolves.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: /^importRun$/i }));
+    await vi.waitFor(() => {
+      expect(bookingsImportConfirm).toHaveBeenCalledWith(
+        "token",
+        expect.objectContaining({
+          sessionId: "s1",
+          importCompleted: true,
+          importDrafts: false,
+        }),
+      );
+    });
+    await expect(screen.findByText("importSummaryLine")).resolves.toBeInTheDocument();
+  });
+
+  it("import summary shows errors list and bulk waybill action", async () => {
+    vi.mocked(bookingsImportPreview).mockResolvedValue({
+      sessionId: "s2",
+      completedCount: 1,
+      draftCount: 0,
+      skippedEmptyRows: 0,
+      totalDataRows: 1,
+    });
+    const errors = Array.from({ length: 9 }, (_, i) => `err-${i}`);
+    vi.mocked(bookingsImportConfirm).mockResolvedValue({
+      createdCount: 1,
+      draftCount: 0,
+      errors,
+      createdBookingIds: ["b1"],
+      draftBookingIds: [],
+    });
+    vi.mocked(bookingsWaybillsBulkDownload).mockResolvedValue(undefined);
+    render(<BookingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [new File(["h"], "t.csv")] } });
+    await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: /^importRun$/i }));
+    await expect(screen.findByText("importErrors")).resolves.toBeInTheDocument();
+    expect(screen.getByText("err-0")).toBeInTheDocument();
+    expect(screen.getByText(/\(\+1 more\)/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /^importDownloadWaybills$/i }));
+    await vi.waitFor(() => {
+      expect(bookingsWaybillsBulkDownload).toHaveBeenCalledWith("token", ["b1"]);
+    });
+  });
+
+  it("import confirm failure shows alert", async () => {
+    vi.mocked(bookingsImportPreview).mockResolvedValue({
+      sessionId: "s3",
+      completedCount: 1,
+      draftCount: 0,
+      skippedEmptyRows: 0,
+      totalDataRows: 1,
+    });
+    vi.mocked(bookingsImportConfirm).mockRejectedValue(new Error("confirm failed"));
+    render(<BookingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /^import$/i }));
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [new File(["h"], "t.csv")] } });
+    await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: /^importRun$/i }));
+    await vi.waitFor(() => {
+      expect(screen.getByRole("alert", { hidden: true })).toHaveTextContent("confirm failed");
+    });
   });
 });

--- a/portal/src/lib/dashboard-wordcloud.test.ts
+++ b/portal/src/lib/dashboard-wordcloud.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("echarts-wordcloud", () => ({}));
+
+import { buildWordCloudOption } from "./dashboard-wordcloud";
+
+const theme = {
+  border: "#ccc",
+  foreground: "#111",
+  mutedForeground: "#666",
+  card: "#fff",
+};
+
+describe("buildWordCloudOption", () => {
+  it("returns null for empty rows", () => {
+    expect(buildWordCloudOption([], ["#a"], theme, "bookings")).toBeNull();
+  });
+
+  it("builds wordCloud series with colors and tooltip formatter", () => {
+    const opt = buildWordCloudOption(
+      [
+        { key: "A", count: 3 },
+        { key: "B", count: 2 },
+      ],
+      ["#f00", "#0f0"],
+      theme,
+      "bookings",
+    );
+    expect(opt).not.toBeNull();
+    const series = opt!.series?.[0] as {
+      type: string;
+      data: { name: string; value: number; textStyle: { color: string } }[];
+    };
+    expect(series?.type).toBe("wordCloud");
+    expect(series?.data[0]).toMatchObject({
+      name: "A",
+      value: 3,
+      textStyle: { color: "#f00" },
+    });
+    expect(series?.data[1].textStyle.color).toBe("#0f0");
+    const fmt = opt!.tooltip?.formatter as (p: unknown) => string;
+    expect(fmt({ name: "X", value: 9 })).toContain("X");
+    expect(fmt({ name: "X", value: 9 })).toContain("9");
+    expect(fmt({})).toContain("bookings");
+  });
+});


### PR DESCRIPTION
PR Validation was failing: portal line coverage ~69.5% (min 75%). Adds dashboard-wordcloud tests and bookings import-flow tests. Local: npm run test:coverage shows ~78% lines and branches.

Made with [Cursor](https://cursor.com)