### PR TITLE
chore: document PR-only flow for main/master (Cursor rule + CLAUDE.md)

### DIFF
--- a/.cursor/rules/git-branch-policy.mdc
+++ b/.cursor/rules/git-branch-policy.mdc
@@ -1,0 +1,13 @@
+---
+description: Git workflow — no direct pushes to main/master; use PRs from development
+alwaysApply: true
+---
+
+# Git branches and releases
+
+- **Never push directly to `main` or `master`** (no `git push origin main`, no `git push origin master` for integrating work).
+- **Integrate work via Pull Request**: open PRs **into `development`** from feature/fix branches. Merge only after review/CI as your team requires.
+- **Promote to production branches via PR only**: merge **`development` → `main`** and **`development` → `master`** (or your documented release PR), not by pushing local merges to those branches.
+- **Do not commit directly on `main`, `master`, or `development`** for feature work; use a branch, then PR into `development`.
+
+When the user asks to “update main/master” or “sync branches”, describe or perform the **PR-based** steps (open merge PRs on GitHub), not direct pushes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,11 @@ docker compose up -d
 
 ## Development Workflow
 
+### Git branches (required)
+
+- **Do not push directly to `main` or `master`.** Land changes with **Pull Requests into `development`**, then promote with **PRs from `development` → `main` / `master`** (never `git push origin main` or `master` to ship work).
+- Use feature/fix branches; avoid committing feature work directly on `development`, `main`, or `master`.
+
 ### Running Locally
 
 **Option 1: Visual Studio (Recommended)**


### PR DESCRIPTION
Never push directly to main or master; integrate via PRs into development, then PR development into main/master.

Made-with: Cursor