### PR TITLE
chore(deploy): minimize downtime (pull before stop, readiness loops)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -42,8 +42,8 @@ flowchart LR
 The Mac workflow is **one job** (must stay on the same machine as Docker). Steps are grouped in the YAML as:
 
 1. **Trigger & repo** — context, checkout at build SHA  
-2. **Registry & host prep** — compose env, Docker Hub login, stop old stack / free ports  
-3. **Image & stack** — `compose pull` (retry), `compose up`  
+2. **Registry & host prep** — compose env, Docker Hub login  
+3. **Image & stack** — `compose pull` (retry) **while the old stack may still be running**, then stop / free ports, then `compose up` (minimizes downtime vs pull-after-down)  
 4. **Smoke checks** — API :8080, portal :3000, nginx :8888  
 5. **Report** — job summary, optional ngrok public URLs  
 

--- a/.github/workflows/docker-deploy-mac.yml
+++ b/.github/workflows/docker-deploy-mac.yml
@@ -6,7 +6,7 @@
 # Sections (single job = same machine as Docker; see .github/workflows/README.md):
 #   §1 Trigger & checkout
 #   §2 Compose env & registry login
-#   §3 Stop old stack & pull image
+#   §3 Pull image while old stack still serves traffic, then stop & start (minimize downtime)
 #   §4 Start stack (compose up)
 #   §5 Smoke tests
 #   §6 Deploy summary & ngrok URLs
@@ -88,7 +88,21 @@ jobs:
             echo "::warning::DOCKERHUB_* missing for login"
           fi
 
-      # ----- §3 Clean host & pull image -----
+      # ----- §3 Pull while old stack is up, then stop (downtime = stop+start only, not pull) -----
+      - name: "§3 · Pull new image (retry, stack may still be running)"
+        run: |
+          set -e
+          export COMPOSE_HTTP_TIMEOUT="${COMPOSE_HTTP_TIMEOUT:-600}"
+          n=1
+          max=6
+          while [ "$n" -le "$max" ]; do
+            echo "compose pull attempt $n/$max (old container still serving if present)..."
+            if $COMPOSE_CMD pull; then break; fi
+            if [ "$n" -eq "$max" ]; then echo "::error::pull failed"; exit 1; fi
+            sleep $((n * 20))
+            n=$((n+1))
+          done
+
       - name: "§3 · Stop stack & free ports (8888, 8080, 3000, 14040)"
         run: |
           set -e
@@ -98,20 +112,6 @@ jobs:
             for id in $(docker ps -q --filter "publish=$port" 2>/dev/null); do
               docker rm -f "$id" || true
             done
-          done
-
-      - name: "§3 · Pull image (retry)"
-        run: |
-          set -e
-          export COMPOSE_HTTP_TIMEOUT="${COMPOSE_HTTP_TIMEOUT:-600}"
-          n=1
-          max=6
-          while [ "$n" -le "$max" ]; do
-            echo "compose pull attempt $n/$max..."
-            if $COMPOSE_CMD pull; then break; fi
-            if [ "$n" -eq "$max" ]; then echo "::error::pull failed"; exit 1; fi
-            sleep $((n * 20))
-            n=$((n+1))
           done
 
       # ----- §4 Start stack -----
@@ -129,8 +129,9 @@ jobs:
       - name: "§4 · Prune dangling images"
         run: docker image prune -f || true
 
-      - name: "§4 · Wait for stack boot"
-        run: sleep 25
+      # Smoke steps retry aggressively; only a short pause so Postgres/API begin binding.
+      - name: "§4 · Brief settle after container start"
+        run: sleep 5
 
       # ----- §5 Smoke tests -----
       - name: "§5 · Smoke — API :8080"

--- a/docker-compose.one.yml
+++ b/docker-compose.one.yml
@@ -6,8 +6,9 @@ services:
   cargohub:
     restart: unless-stopped
     image: maleesha404/cargohub:latest
-    # Always pull :latest on deploy so GitHub Actions / compose up actually updates the container
-    pull_policy: always
+    # CI runs `compose pull` before `down` so deploy downtime excludes pull; `up` uses cached layers.
+    # For a manual fresh image: `docker compose pull && docker compose up -d`
+    pull_policy: missing
     container_name: cargohub
     ports:
       - "8888:8888"

--- a/docker/start-all-in-one.sh
+++ b/docker/start-all-in-one.sh
@@ -34,8 +34,20 @@ export Jwt__SigningKey="${Jwt__SigningKey:-DemoJwtKey-ChangeMe-AtLeast32Chars}"
 cd /app/api && dotnet CargoHub.Api.dll &
 APIPID=$!
 
-# Give API time to start and run migrations
-sleep 5
+echo "Waiting for API on :8080 (migrations may run on first start)..."
+i=0
+while [ "$i" -lt 180 ]; do
+  if curl -sfS "http://127.0.0.1:8080/api/v1/health_" >/dev/null 2>&1; then
+    echo "API is up."
+    break
+  fi
+  i=$((i + 1))
+  sleep 1
+done
+if [ "$i" -ge 180 ]; then
+  echo "ERROR: API did not become ready on :8080 within 180s"
+  exit 1
+fi
 
 # Next.js on :3000 (nginx will expose :8888 to the internet via ngrok)
 cd /app/portal
@@ -46,7 +58,18 @@ npm run start &
 NEXT_PID=$!
 
 echo "Waiting for Next.js on :3000..."
-sleep 12
+i=0
+while [ "$i" -lt 120 ]; do
+  if curl -sfS -o /dev/null "http://127.0.0.1:3000/" 2>/dev/null; then
+    echo "Next.js is up."
+    break
+  fi
+  i=$((i + 1))
+  sleep 1
+done
+if [ "$i" -ge 120 ]; then
+  echo "WARNING: Next.js did not respond on :3000 within 120s; continuing to start nginx"
+fi
 
 # Reverse proxy: one public port — /api -> ASP.NET :8080, / -> Next :3000
 if nginx -t 2>/dev/null; then


### PR DESCRIPTION
Pull image while old stack may still serve; \pull_policy: missing\ on up; readiness loops in start-all-in-one.sh; shorter pre-smoke sleep. See commit message for details.

Made with [Cursor](https://cursor.com)