### PR TITLE
fix(deploy): extend smokes for Migrate() blocking HTTP

### DIFF
--- a/.github/workflows/docker-deploy-mac.yml
+++ b/.github/workflows/docker-deploy-mac.yml
@@ -129,7 +129,8 @@ jobs:
       - name: "§4 · Prune dangling images"
         run: docker image prune -f || true
 
-      # Entrypoint can take minutes (Postgres + EF migrate + Next). Short sleep alone is not enough; smokes retry below.
+      # API does not listen until after EF Migrate() + role seed in Program.cs (blocks before app.Run).
+      # Postgres recovery after unclean deploy stop can add more delay. Allow ~15+ min before failing smokes.
       - name: "§4 · Brief settle after container start"
         run: sleep 15
 
@@ -137,19 +138,19 @@ jobs:
       - name: "§5 · Smoke — API :8080"
         run: |
           set -e
-          curl -sfS --retry 40 --retry-delay 5 --retry-all-errors "http://localhost:8080/api/v1/health_"
+          curl -sfS --retry 120 --retry-delay 5 --retry-all-errors "http://localhost:8080/api/v1/health_"
 
       - name: "§5 · Smoke — Portal :3000"
         run: |
           set -e
-          # next-intl localePrefix: always — bare / may 404
-          curl -sfS --retry 40 --retry-delay 5 --retry-all-errors -o /dev/null "http://localhost:3000/en/"
+          # next-intl localePrefix: always — bare / may 404; starts after API wait inside container
+          curl -sfS --retry 120 --retry-delay 5 --retry-all-errors -o /dev/null "http://localhost:3000/en/"
 
       - name: "§5 · Smoke — nginx :8888"
         run: |
           set -e
-          curl -sfS --retry 40 --retry-delay 5 --retry-all-errors "http://localhost:8888/api/v1/health_"
-          curl -sfS --retry 40 --retry-delay 5 --retry-all-errors -o /dev/null "http://localhost:8888/en/"
+          curl -sfS --retry 120 --retry-delay 5 --retry-all-errors "http://localhost:8888/api/v1/health_"
+          curl -sfS --retry 120 --retry-delay 5 --retry-all-errors -o /dev/null "http://localhost:8888/en/"
 
       - name: "§5 · Diagnose on smoke failure (container logs)"
         if: failure()

--- a/docker/start-all-in-one.sh
+++ b/docker/start-all-in-one.sh
@@ -34,8 +34,8 @@ export Jwt__SigningKey="${Jwt__SigningKey:-DemoJwtKey-ChangeMe-AtLeast32Chars}"
 cd /app/api && dotnet CargoHub.Api.dll &
 APIPID=$!
 
-# EF migrations on a slow disk (e.g. self-hosted Mac) can exceed 3m; exiting here stops the container and breaks host smokes.
-API_WAIT_MAX="${CARGOHUB_API_WAIT_MAX:-600}"
+# Program.cs runs Migrate() before Kestrel listens; on slow IO this can exceed 10m. Match host smoke retries (~15m).
+API_WAIT_MAX="${CARGOHUB_API_WAIT_MAX:-900}"
 echo "Waiting for API on :8080 (migrations may run on first start, max ${API_WAIT_MAX}s)..."
 i=0
 while [ "$i" -lt "$API_WAIT_MAX" ]; do


### PR DESCRIPTION
Root cause of \curl: (56) Recv failure: Connection reset by peer\: nothing listens on :8080 until \Program.cs\ finishes \Database.Migrate()\ and role seeding. Prior smokes timed out first.

- \curl --retry 120\ (was 40)
- \API_WAIT_MAX\ default 900s (was 600s)

Made with [Cursor](https://cursor.com)