### PR TITLE
fix(deploy): prevent startup crash from duplicate Theme migration

### DIFF
--- a/CargoHub.Infrastructure/Migrations/20260325041843_AddBookingImportFileMappings.cs
+++ b/CargoHub.Infrastructure/Migrations/20260325041843_AddBookingImportFileMappings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -11,12 +11,7 @@ namespace CargoHub.Infrastructure.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AddColumn<string>(
-                name: "Theme",
-                schema: "auth",
-                table: "AspNetUsers",
-                type: "text",
-                nullable: true);
+            // Theme is added by migration 20260317053643_AddUserThemePreference; do not duplicate (breaks deploy on DBs that already have the column).
 
             migrationBuilder.CreateTable(
                 name: "BookingImportFileMappings",
@@ -57,11 +52,6 @@ namespace CargoHub.Infrastructure.Migrations
             migrationBuilder.DropTable(
                 name: "BookingImportFileMappings",
                 schema: "companies");
-
-            migrationBuilder.DropColumn(
-                name: "Theme",
-                schema: "auth",
-                table: "AspNetUsers");
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove duplicate Theme column changes from migration 20260325041843_AddBookingImportFileMappings
- keep Theme ownership in migration 20260317053643_AddUserThemePreference to avoid Postgres column already exists startup crash
- unblock API startup so deployment smoke checks can reach /api/v1/health_

## Test plan
- [x] dotnet build CargoHub.Backend.sln -v q
- [x] dotnet test CargoHub.Tests/CargoHub.Tests.csproj --no-build -v q
- [x] dotnet test CargoHub.Backend.sln --no-build --configuration Release --collect:XPlat Code Coverage --results-directory ./TestResults --settings coverlet.runsettings
- [x] backend coverage from generated Cobertura: line 85.82%, branch 75.53%
- [x] cd portal && npm run test -- --coverage (frontend lines 77.3%)
