### PR TITLE
fix(smtp): appsettings defaults + fill empty Host/From after env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,7 @@ Cors__PortalOrigin=http://localhost:3000
 # ---- SMTP (invites, password reset, courier emails) ----
 # Use placeholders here only. Put real credentials in .env (gitignored), never in .env.example.
 # Google Workspace / Gmail SMTP: Host=smtp.gmail.com Port=587 UseSsl=true UserName=full email App Password
+# IMPORTANT: Do not set Smtp__Host= with no value — empty env vars override appsettings and clear the host.
 Smtp__Host=smtp.example.com
 Smtp__Port=587
 Smtp__UseSsl=true

--- a/CargoHub.Api/appsettings.json
+++ b/CargoHub.Api/appsettings.json
@@ -1,4 +1,12 @@
 {
+  "Smtp": {
+    "Host": "smtp.example.com",
+    "Port": 587,
+    "UseSsl": true,
+    "UserName": "",
+    "Password": "",
+    "FromAddress": "noreply@example.com"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/CargoHub.Infrastructure/Couriers/ServiceCollectionExtensions.cs
+++ b/CargoHub.Infrastructure/Couriers/ServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class ServiceCollectionExtensions
         services.Configure<HameenTavarataxiOptions>(configuration.GetSection(HameenTavarataxiOptions.SectionName));
         services.Configure<SmtpOptions>(configuration.GetSection(SmtpOptions.SectionName));
         services.AddSingleton<IConfigureOptions<SmtpOptions>, SmtpOptionsLegacyEnvironmentConfigurer>();
+        services.AddSingleton<IPostConfigureOptions<SmtpOptions>, SmtpOptionsPostConfigureFillEmpty>();
 
         services.AddSingleton<IEmailSender, SmtpEmailSender>();
 

--- a/CargoHub.Infrastructure/Couriers/SmtpEmailSender.cs
+++ b/CargoHub.Infrastructure/Couriers/SmtpEmailSender.cs
@@ -23,7 +23,9 @@ public sealed class SmtpEmailSender : IEmailSender
     public async Task SendAsync(string to, string subject, string htmlBody, IReadOnlyList<EmailAttachment> attachments, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(_options.Host))
-            throw new InvalidOperationException("SmtpOptions.Host is not configured.");
+            throw new InvalidOperationException(
+                "SmtpOptions.Host is not configured. Set Smtp:Host in appsettings, or environment variable Smtp__Host, " +
+                "or legacy SMTP_SERVER_EMAIL / SMTP_HOST. If you use a .env file, remove Smtp__Host when unused (an empty value overrides appsettings).");
 
         using var client = new SmtpClient(_options.Host, _options.Port);
         client.EnableSsl = _options.UseSsl;

--- a/CargoHub.Infrastructure/Couriers/SmtpOptionsPostConfigureFillEmpty.cs
+++ b/CargoHub.Infrastructure/Couriers/SmtpOptionsPostConfigureFillEmpty.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Options;
+
+namespace CargoHub.Infrastructure.Couriers;
+
+/// <summary>
+/// Runs after all configuration sources. If <see cref="SmtpOptions.Host"/> or <see cref="SmtpOptions.FromAddress"/>
+/// are still blank (common when <c>Smtp__Host=</c> in <c>.env</c> overrides appsettings with an empty string),
+/// applies the same placeholders as <c>appsettings.json</c> so the app fails at SMTP connect/auth instead of
+/// "Host is not configured".
+/// </summary>
+public sealed class SmtpOptionsPostConfigureFillEmpty : IPostConfigureOptions<SmtpOptions>
+{
+    public void PostConfigure(string? name, SmtpOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.Host))
+            options.Host = "smtp.example.com";
+
+        if (string.IsNullOrWhiteSpace(options.FromAddress))
+            options.FromAddress = "noreply@example.com";
+    }
+}


### PR DESCRIPTION
Base appsettings.json Smtp placeholders; IPostConfigureOptions fills blank host/from when .env overrides with empty string; clearer error message; .env.example note.

Made with [Cursor](https://cursor.com)