### PR TITLE
fix(portal): dev /api proxy; admin company + invite helper tests

### DIFF
--- a/CargoHub.Tests/AdminCompanies/CreateAdminCompanyCommandHandlerTests.cs
+++ b/CargoHub.Tests/AdminCompanies/CreateAdminCompanyCommandHandlerTests.cs
@@ -1,0 +1,177 @@
+using CargoHub.Application.AdminCompanies;
+using CargoHub.Application.Company;
+using Moq;
+using Xunit;
+using CompanyEntity = CargoHub.Domain.Companies.Company;
+
+namespace CargoHub.Tests.AdminCompanies;
+
+public class CreateAdminCompanyCommandHandlerTests
+{
+    private static CreateAdminCompanyCommandHandler CreateHandler(
+        out Mock<ICompanyRepository> repo,
+        out Mock<ICompanyAdminInviteIssuer> invites,
+        out Mock<ICompanyUserMetrics> metrics)
+    {
+        repo = new Mock<ICompanyRepository>();
+        invites = new Mock<ICompanyAdminInviteIssuer>();
+        metrics = new Mock<ICompanyUserMetrics>();
+        return new CreateAdminCompanyCommandHandler(repo.Object, invites.Object, metrics.Object);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyName_Fails()
+    {
+        var h = CreateHandler(out _, out _, out _);
+        var r = await h.Handle(new CreateAdminCompanyCommand("", "bid", 10, 2, null), default);
+        Assert.False(r.Success);
+        Assert.Equal("NameRequired", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_WhitespaceOnlyName_Fails()
+    {
+        var h = CreateHandler(out _, out _, out _);
+        var r = await h.Handle(new CreateAdminCompanyCommand("   ", "bid", 10, 2, null), default);
+        Assert.False(r.Success);
+        Assert.Equal("NameRequired", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_TrimsNameAndBusinessId()
+    {
+        var h = CreateHandler(out var repo, out var invites, out var metrics);
+        repo.Setup(x => x.GetByBusinessIdAsync("bid", default)).ReturnsAsync((CompanyEntity?)null);
+        CompanyEntity? created = null;
+        repo.Setup(x => x.CreateAsync(It.IsAny<CompanyEntity>(), default))
+            .Callback<CompanyEntity, CancellationToken>((c, _) => created = c)
+            .ReturnsAsync((CompanyEntity c, CancellationToken _) => c);
+        repo.Setup(x => x.GetByIdAsync(It.IsAny<Guid>(), default))
+            .ReturnsAsync((Guid id, CancellationToken _) => created!.Id == id ? created : null);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("bid", default)).ReturnsAsync(0);
+
+        var r = await h.Handle(
+            new CreateAdminCompanyCommand("  Acme  ", "  bid  ", 10, 5, null),
+            default);
+
+        Assert.True(r.Success);
+        Assert.Equal("Acme", r.Company!.Name);
+        Assert.Equal("bid", r.Company.BusinessId);
+        invites.Verify(
+            x => x.TryIssueInitialAdminInvitesAsync(It.IsAny<Guid>(), "bid", null, default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyBusinessId_Fails()
+    {
+        var h = CreateHandler(out _, out _, out _);
+        var r = await h.Handle(new CreateAdminCompanyCommand("Co", "  ", 10, 2, null), default);
+        Assert.False(r.Success);
+        Assert.Equal("BusinessIdRequired", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_MaxUsersBelowOne_Fails()
+    {
+        var h = CreateHandler(out _, out _, out _);
+        var r = await h.Handle(new CreateAdminCompanyCommand("Co", "bid", 0, 2, null), default);
+        Assert.False(r.Success);
+        Assert.Equal("InvalidMaxUsers", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_MaxAdminsBelowOne_Fails()
+    {
+        var h = CreateHandler(out _, out _, out _);
+        var r = await h.Handle(new CreateAdminCompanyCommand("Co", "bid", 10, 0, null), default);
+        Assert.False(r.Success);
+        Assert.Equal("InvalidMaxAdmins", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateBusinessId_Fails()
+    {
+        var h = CreateHandler(out var repo, out _, out _);
+        repo.Setup(x => x.GetByBusinessIdAsync("dup", default)).ReturnsAsync(new CompanyEntity { BusinessId = "dup" });
+
+        var r = await h.Handle(new CreateAdminCompanyCommand("Co", "dup", 10, 5, null), default);
+        Assert.False(r.Success);
+        Assert.Equal("BusinessIdExists", r.ErrorCode);
+        repo.Verify(x => x.CreateAsync(It.IsAny<CompanyEntity>(), default), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_TooManyInviteEmails_Fails()
+    {
+        var h = CreateHandler(out var repo, out _, out _);
+        repo.Setup(x => x.GetByBusinessIdAsync("bid", default)).ReturnsAsync((CompanyEntity?)null);
+
+        var emails = new[] { "a@test.com", "b@test.com", "c@test.com" };
+        var r = await h.Handle(new CreateAdminCompanyCommand("Co", "bid", 10, 2, emails), default);
+        Assert.False(r.Success);
+        Assert.Equal("TooManyInviteEmails", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_Success_IssuesInvitesWhenNoAdmins()
+    {
+        var h = CreateHandler(out var repo, out var invites, out var metrics);
+        repo.Setup(x => x.GetByBusinessIdAsync("1234567-8", default)).ReturnsAsync((CompanyEntity?)null);
+        CompanyEntity? created = null;
+        repo.Setup(x => x.CreateAsync(It.IsAny<CompanyEntity>(), default))
+            .Callback<CompanyEntity, CancellationToken>((c, _) => created = c)
+            .ReturnsAsync((CompanyEntity c, CancellationToken _) => c);
+        repo.Setup(x => x.GetByIdAsync(It.IsAny<Guid>(), default))
+            .ReturnsAsync((Guid id, CancellationToken _) => created!.Id == id ? created : null);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("1234567-8", default)).ReturnsAsync(0);
+
+        var r = await h.Handle(
+            new CreateAdminCompanyCommand("Acme", "1234567-8", 50, 5, new[] { "admin@test.com" }),
+            default);
+
+        Assert.True(r.Success);
+        Assert.NotNull(r.Company);
+        Assert.Equal("Acme", r.Company!.Name);
+        invites.Verify(
+            x => x.TryIssueInitialAdminInvitesAsync(created!.Id, "1234567-8", It.IsAny<IReadOnlyList<string>>(), default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_Success_SkipsInvitesWhenAdminsAlreadyExist()
+    {
+        var h = CreateHandler(out var repo, out var invites, out var metrics);
+        repo.Setup(x => x.GetByBusinessIdAsync("bid", default)).ReturnsAsync((CompanyEntity?)null);
+        CompanyEntity? created = null;
+        repo.Setup(x => x.CreateAsync(It.IsAny<CompanyEntity>(), default))
+            .Callback<CompanyEntity, CancellationToken>((c, _) => created = c)
+            .ReturnsAsync((CompanyEntity c, CancellationToken _) => c);
+        repo.Setup(x => x.GetByIdAsync(It.IsAny<Guid>(), default))
+            .ReturnsAsync((Guid id, CancellationToken _) => created!.Id == id ? created : null);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("bid", default)).ReturnsAsync(2);
+
+        var r = await h.Handle(new CreateAdminCompanyCommand("Co", "bid", 10, 5, null), default);
+
+        Assert.True(r.Success);
+        invites.Verify(
+            x => x.TryIssueInitialAdminInvitesAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<string>?>(), default),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_Success_GetByIdNullAfterCreate_Fails()
+    {
+        var h = CreateHandler(out var repo, out _, out var metrics);
+        repo.Setup(x => x.GetByBusinessIdAsync("bid", default)).ReturnsAsync((CompanyEntity?)null);
+        repo.Setup(x => x.CreateAsync(It.IsAny<CompanyEntity>(), default))
+            .ReturnsAsync((CompanyEntity c, CancellationToken _) => c);
+        repo.Setup(x => x.GetByIdAsync(It.IsAny<Guid>(), default)).ReturnsAsync((CompanyEntity?)null);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("bid", default)).ReturnsAsync(0);
+
+        var r = await h.Handle(new CreateAdminCompanyCommand("Co", "bid", 10, 5, null), default);
+
+        Assert.False(r.Success);
+        Assert.Equal("NotFound", r.ErrorCode);
+    }
+}

--- a/CargoHub.Tests/AdminCompanies/UpdateAdminCompanyCommandHandlerTests.cs
+++ b/CargoHub.Tests/AdminCompanies/UpdateAdminCompanyCommandHandlerTests.cs
@@ -1,0 +1,282 @@
+using CargoHub.Application.AdminCompanies;
+using CargoHub.Application.Company;
+using Moq;
+using Xunit;
+using CompanyEntity = CargoHub.Domain.Companies.Company;
+
+namespace CargoHub.Tests.AdminCompanies;
+
+public class UpdateAdminCompanyCommandHandlerTests
+{
+    private static UpdateAdminCompanyCommandHandler CreateHandler(
+        out Mock<ICompanyRepository> repo,
+        out Mock<ICompanyAdminInviteIssuer> invites,
+        out Mock<ICompanyUserMetrics> metrics,
+        out Mock<IAdminCompanyLimitUserOperations> limits)
+    {
+        repo = new Mock<ICompanyRepository>();
+        invites = new Mock<ICompanyAdminInviteIssuer>();
+        metrics = new Mock<ICompanyUserMetrics>();
+        limits = new Mock<IAdminCompanyLimitUserOperations>();
+        return new UpdateAdminCompanyCommandHandler(repo.Object, invites.Object, metrics.Object, limits.Object);
+    }
+
+    private static CompanyEntity TrackedCompany(Guid id, string bid = "BIZ-1") => new()
+    {
+        Id = id,
+        Name = "Co",
+        BusinessId = bid,
+        CompanyId = "cid",
+        MaxUserAccounts = 10,
+        MaxAdminAccounts = 3
+    };
+
+    [Fact]
+    public async Task Handle_MaxUsersBelowOne_Fails()
+    {
+        var h = CreateHandler(out _, out _, out _, out _);
+        var r = await h.Handle(new UpdateAdminCompanyCommand(Guid.NewGuid(), 0, null, false, null, null), default);
+        Assert.False(r.Success);
+        Assert.Equal("InvalidMaxUsers", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_MaxAdminsBelowOne_Fails()
+    {
+        var h = CreateHandler(out _, out _, out _, out _);
+        var r = await h.Handle(new UpdateAdminCompanyCommand(Guid.NewGuid(), null, 0, false, null, null), default);
+        Assert.False(r.Success);
+        Assert.Equal("InvalidMaxAdmins", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_CompanyNotFound_Fails()
+    {
+        var h = CreateHandler(out var repo, out _, out _, out _);
+        var id = Guid.NewGuid();
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync((CompanyEntity?)null);
+
+        var r = await h.Handle(new UpdateAdminCompanyCommand(id, 5, 2, false, null, null), default);
+        Assert.False(r.Success);
+        Assert.Equal("NotFound", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_LimitReduction_NeedsMoreDemotions_ReturnsConflict()
+    {
+        var id = Guid.NewGuid();
+        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(TrackedCompany(id));
+        metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(3);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(4);
+
+        var r = await h.Handle(new UpdateAdminCompanyCommand(id, 10, 2, false, null, null), default);
+
+        Assert.False(r.Success);
+        Assert.Equal("LimitReductionRequired", r.ErrorCode);
+        Assert.NotNull(r.LimitReductionRequired);
+        Assert.Equal(2, r.LimitReductionRequired!.MinimumAdminsToDemote);
+    }
+
+    [Fact]
+    public async Task Handle_LimitReduction_NeedsMoreDeactivations_ReturnsConflict()
+    {
+        var id = Guid.NewGuid();
+        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(TrackedCompany(id));
+        metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(12);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+
+        var r = await h.Handle(new UpdateAdminCompanyCommand(id, 5, 3, false, null, null), default);
+
+        Assert.False(r.Success);
+        Assert.Equal("LimitReductionRequired", r.ErrorCode);
+        Assert.True(r.LimitReductionRequired!.MinimumUsersToDeactivate > 0);
+    }
+
+    [Fact]
+    public async Task Handle_UnexpectedDemotions_Fails()
+    {
+        var id = Guid.NewGuid();
+        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(TrackedCompany(id));
+        metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+
+        var r = await h.Handle(
+            new UpdateAdminCompanyCommand(id, 10, 3, false, null, new[] { "user-1" }),
+            default);
+
+        Assert.False(r.Success);
+        Assert.Equal("UnexpectedDemotions", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_UnexpectedDeactivations_Fails()
+    {
+        var id = Guid.NewGuid();
+        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(TrackedCompany(id));
+        metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+
+        var r = await h.Handle(
+            new UpdateAdminCompanyCommand(id, 10, 3, false, new[] { "u1" }, null),
+            default);
+
+        Assert.False(r.Success);
+        Assert.Equal("UnexpectedDeactivations", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_DemoteFails_ReturnsError()
+    {
+        var id = Guid.NewGuid();
+        var h = CreateHandler(out var repo, out _, out var metrics, out var limits);
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(TrackedCompany(id));
+        metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(4);
+        limits.Setup(x => x.DemoteAdminsAsync("BIZ-1", It.IsAny<IReadOnlyList<string>>(), default))
+            .ReturnsAsync("boom");
+
+        var r = await h.Handle(
+            new UpdateAdminCompanyCommand(id, 10, 2, false, null, new[] { "a", "b" }),
+            default);
+
+        Assert.False(r.Success);
+        Assert.Equal("DemoteFailed", r.ErrorCode);
+        Assert.Equal("boom", r.Message);
+    }
+
+    [Fact]
+    public async Task Handle_DeactivateFails_ReturnsError()
+    {
+        var id = Guid.NewGuid();
+        var h = CreateHandler(out var repo, out _, out var metrics, out var limits);
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(TrackedCompany(id));
+        metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(12);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        limits.Setup(x => x.DeactivateUsersAsync("BIZ-1", It.IsAny<IReadOnlyList<string>>(), default))
+            .ReturnsAsync("nope");
+
+        var deactivateIds = Enumerable.Range(1, 7).Select(i => $"u{i}").ToList();
+        var r = await h.Handle(
+            new UpdateAdminCompanyCommand(id, 5, 3, false, deactivateIds, null),
+            default);
+
+        Assert.False(r.Success);
+        Assert.Equal("DeactivateFailed", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_Success_UpdatesLimits()
+    {
+        var id = Guid.NewGuid();
+        var company = TrackedCompany(id);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
+        metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        repo.Setup(x => x.UpdateAsync(company, default)).ReturnsAsync(company);
+        repo.Setup(x => x.GetByIdAsync(id, default)).ReturnsAsync(company);
+
+        var r = await h.Handle(new UpdateAdminCompanyCommand(id, 7, 2, false, null, null), default);
+
+        Assert.True(r.Success);
+        Assert.Equal(7, r.Company!.MaxUserAccounts);
+        Assert.Equal(2, r.Company.MaxAdminAccounts);
+    }
+
+    [Fact]
+    public async Task Handle_ResendInvite_NoBusinessId_Fails()
+    {
+        var id = Guid.NewGuid();
+        var company = TrackedCompany(id, "");
+        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
+        metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("", default)).ReturnsAsync(0);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("", default)).ReturnsAsync(0);
+        repo.Setup(x => x.UpdateAsync(company, default)).ReturnsAsync(company);
+
+        var r = await h.Handle(new UpdateAdminCompanyCommand(id, null, null, true, null, null), default);
+
+        Assert.False(r.Success);
+        Assert.Equal("BusinessIdRequired", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_ResendInvite_AlreadyHasAdmin_Fails()
+    {
+        var id = Guid.NewGuid();
+        var company = TrackedCompany(id);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
+        metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        repo.Setup(x => x.UpdateAsync(company, default)).ReturnsAsync(company);
+
+        var r = await h.Handle(new UpdateAdminCompanyCommand(id, null, null, true, null, null), default);
+
+        Assert.False(r.Success);
+        Assert.Equal("AlreadyHasAdmin", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_ResendInvite_Success_CallsIssuer()
+    {
+        var id = Guid.NewGuid();
+        var company = TrackedCompany(id);
+        company.InitialAdminInviteEmail = "a@test.com";
+        var h = CreateHandler(out var repo, out var invites, out var metrics, out _);
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
+        metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        metrics.SetupSequence(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default))
+            .ReturnsAsync(1)
+            .ReturnsAsync(0)
+            .ReturnsAsync(0);
+
+        repo.Setup(x => x.UpdateAsync(company, default)).ReturnsAsync(company);
+        repo.Setup(x => x.GetByIdAsync(id, default)).ReturnsAsync(company);
+
+        var r = await h.Handle(new UpdateAdminCompanyCommand(id, null, null, true, null, null), default);
+
+        Assert.True(r.Success);
+        invites.Verify(
+            x => x.TryIssueInitialAdminInvitesAsync(id, "BIZ-1", It.IsAny<IReadOnlyList<string>?>(), default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NotFoundAfterUpdate_Fails()
+    {
+        var id = Guid.NewGuid();
+        var company = TrackedCompany(id);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
+        metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        repo.Setup(x => x.UpdateAsync(company, default)).ReturnsAsync(company);
+        repo.Setup(x => x.GetByIdAsync(id, default)).ReturnsAsync((CompanyEntity?)null);
+
+        var r = await h.Handle(new UpdateAdminCompanyCommand(id, 8, null, false, null, null), default);
+
+        Assert.False(r.Success);
+        Assert.Equal("NotFound", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyBusinessId_UsesZeroCounts()
+    {
+        var id = Guid.NewGuid();
+        var company = TrackedCompany(id, "");
+        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
+        repo.Setup(x => x.UpdateAsync(company, default)).ReturnsAsync(company);
+        repo.Setup(x => x.GetByIdAsync(id, default)).ReturnsAsync(company);
+
+        var r = await h.Handle(new UpdateAdminCompanyCommand(id, 5, null, false, null, null), default);
+
+        Assert.True(r.Success);
+        metrics.Verify(x => x.CountActiveUsersForBusinessIdAsync(It.IsAny<string>(), default), Times.Never);
+    }
+}

--- a/CargoHub.Tests/Company/CompanyAdminInviteAddressTests.cs
+++ b/CargoHub.Tests/Company/CompanyAdminInviteAddressTests.cs
@@ -1,0 +1,85 @@
+using CargoHub.Application.Company;
+using Xunit;
+
+namespace CargoHub.Tests.Company;
+
+public class CompanyAdminInviteAddressTests
+{
+    [Fact]
+    public void SanitizeLocalPart_Null_ReturnsCompany()
+    {
+        Assert.Equal("company", CompanyAdminInviteAddress.SanitizeLocalPart(null!));
+    }
+
+    [Theory]
+    [InlineData("", "company")]
+    [InlineData("   ", "company")]
+    public void SanitizeLocalPart_EmptyOrWhitespace_ReturnsCompany(string input, string expected)
+    {
+        Assert.Equal(expected, CompanyAdminInviteAddress.SanitizeLocalPart(input));
+    }
+
+    [Fact]
+    public void SanitizeLocalPart_KeepsAsciiLettersAndDigits()
+    {
+        Assert.Equal("ab12", CompanyAdminInviteAddress.SanitizeLocalPart("Ab12"));
+    }
+
+    [Fact]
+    public void SanitizeLocalPart_AllowsSafePunctuation_TrimsTrailingHyphenFromResult()
+    {
+        Assert.Equal("a._+%", CompanyAdminInviteAddress.SanitizeLocalPart("a._+%-"));
+    }
+
+    [Fact]
+    public void SanitizeLocalPart_ReplacesUnsafeCharsWithHyphen()
+    {
+        Assert.Equal("a-b", CompanyAdminInviteAddress.SanitizeLocalPart("a@b"));
+    }
+
+    [Fact]
+    public void SanitizeLocalPart_CollapsesDoubleHyphens()
+    {
+        Assert.Equal("a-b", CompanyAdminInviteAddress.SanitizeLocalPart("a--b"));
+    }
+
+    [Fact]
+    public void SanitizeLocalPart_TrimsLeadingTrailingHyphensFromSegment()
+    {
+        Assert.Equal("x", CompanyAdminInviteAddress.SanitizeLocalPart("-x-"));
+    }
+
+    [Fact]
+    public void SanitizeLocalPart_AllNonSafeBecomesEmpty_UsesCompany()
+    {
+        Assert.Equal("company", CompanyAdminInviteAddress.SanitizeLocalPart("@@@"));
+    }
+
+    [Fact]
+    public void SanitizeLocalPart_TruncatesToMaxLocalPartLength()
+    {
+        var longId = new string('a', CompanyAdminInviteAddress.MaxLocalPartLength + 20);
+        var s = CompanyAdminInviteAddress.SanitizeLocalPart(longId);
+        Assert.Equal(CompanyAdminInviteAddress.MaxLocalPartLength, s.Length);
+    }
+
+    [Fact]
+    public void SanitizeLocalPart_TruncationTrimsTrailingHyphen()
+    {
+        var pad = new string('a', CompanyAdminInviteAddress.MaxLocalPartLength - 1);
+        var input = pad + "---b";
+        var s = CompanyAdminInviteAddress.SanitizeLocalPart(input);
+        Assert.True(s.Length <= CompanyAdminInviteAddress.MaxLocalPartLength);
+        Assert.False(s.EndsWith('-'));
+    }
+
+    [Theory]
+    [InlineData("123", null, "123@example.com")]
+    [InlineData("123", "", "123@example.com")]
+    [InlineData("123", "  ", "123@example.com")]
+    [InlineData("123", "mail.example.com", "123@mail.example.com")]
+    public void BuildFallbackEmail_UsesSanitizedLocalAndDomain(string bid, string? domain, string expected)
+    {
+        Assert.Equal(expected, CompanyAdminInviteAddress.BuildFallbackEmail(bid, domain!));
+    }
+}

--- a/CargoHub.Tests/Company/CompanyAdminInviteEmailsHelperTests.cs
+++ b/CargoHub.Tests/Company/CompanyAdminInviteEmailsHelperTests.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using CargoHub.Application.Company;
+using Xunit;
+
+namespace CargoHub.Tests.Company;
+
+public class CompanyAdminInviteEmailsHelperTests
+{
+    [Fact]
+    public void NormalizeList_Null_ReturnsEmpty()
+    {
+        Assert.Empty(CompanyAdminInviteEmailsHelper.NormalizeList(null));
+    }
+
+    [Fact]
+    public void NormalizeList_TrimsDistinctCaseInsensitive()
+    {
+        var list = CompanyAdminInviteEmailsHelper.NormalizeList(new[] { " A@b.com ", "a@B.com", "", "  " });
+        Assert.Single(list);
+        Assert.Equal("A@b.com", list[0]);
+    }
+
+    [Fact]
+    public void SerializeJson_EmptyAfterNormalize_ReturnsNull()
+    {
+        Assert.Null(CompanyAdminInviteEmailsHelper.SerializeJson(Array.Empty<string>()));
+        Assert.Null(CompanyAdminInviteEmailsHelper.SerializeJson(new[] { "  ", "" }));
+    }
+
+    [Fact]
+    public void SerializeJson_RoundTripsThroughDeserialize()
+    {
+        var emails = new[] { "one@test.com", "two@test.com" };
+        var json = CompanyAdminInviteEmailsHelper.SerializeJson(emails);
+        Assert.NotNull(json);
+        var back = CompanyAdminInviteEmailsHelper.DeserializeJson(json);
+        Assert.Equal(2, back.Count);
+        Assert.Contains("one@test.com", back);
+        Assert.Contains("two@test.com", back);
+    }
+
+    [Fact]
+    public void DeserializeJson_NullOrWhiteSpace_ReturnsEmpty()
+    {
+        Assert.Empty(CompanyAdminInviteEmailsHelper.DeserializeJson(null));
+        Assert.Empty(CompanyAdminInviteEmailsHelper.DeserializeJson("   "));
+    }
+
+    [Fact]
+    public void DeserializeJson_InvalidJson_ReturnsEmpty()
+    {
+        Assert.Empty(CompanyAdminInviteEmailsHelper.DeserializeJson("{"));
+    }
+
+    [Fact]
+    public void GetExplicitTargets_PrefersJsonOverLegacy()
+    {
+        var json = JsonSerializer.Serialize(new[] { "json@test.com" });
+        var targets = CompanyAdminInviteEmailsHelper.GetExplicitTargets(json, "legacy@test.com");
+        Assert.Single(targets);
+        Assert.Equal("json@test.com", targets[0]);
+    }
+
+    [Fact]
+    public void GetExplicitTargets_FallsBackToLegacy()
+    {
+        var targets = CompanyAdminInviteEmailsHelper.GetExplicitTargets(null, "  legacy@test.com  ");
+        Assert.Single(targets);
+        Assert.Equal("legacy@test.com", targets[0]);
+    }
+
+    [Fact]
+    public void GetExplicitTargets_EmptyJsonUsesLegacy()
+    {
+        var targets = CompanyAdminInviteEmailsHelper.GetExplicitTargets("[]", "legacy@test.com");
+        Assert.Single(targets);
+        Assert.Equal("legacy@test.com", targets[0]);
+    }
+}

--- a/portal/.env.example
+++ b/portal/.env.example
@@ -2,4 +2,7 @@
 # Sync to GitHub Secrets as NEXT_PUBLIC_API_URL for Vercel/build-time injection.
 # See https://nextjs.org/docs/app/building-your-application/configuring/environment-variables
 
+# Point at the CargoHub.Api URL (default local: http://localhost:5299). If unset or __SAME_ORIGIN__,
+# `npm run dev` proxies /api/* to API_PROXY_TARGET (default http://localhost:5299) so admin/test-email works.
 NEXT_PUBLIC_API_URL=http://localhost:5299
+# API_PROXY_TARGET=http://localhost:5299

--- a/portal/next.config.ts
+++ b/portal/next.config.ts
@@ -3,6 +3,21 @@ import createNextIntlPlugin from "next-intl/plugin";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
-const nextConfig: NextConfig = {};
+/**
+ * When the portal runs on :3000 with NEXT_PUBLIC_API_URL unset or __SAME_ORIGIN__, browser fetch uses
+ * window.location.origin, so /api/* would hit Next.js and return 404. Proxy /api to the .NET API in dev.
+ */
+const publicApiUrl = process.env.NEXT_PUBLIC_API_URL?.trim() ?? "";
+const useDevApiRewrite =
+  process.env.NODE_ENV === "development" &&
+  (publicApiUrl === "" || publicApiUrl === "__SAME_ORIGIN__");
+
+const nextConfig: NextConfig = {
+  async rewrites() {
+    if (!useDevApiRewrite) return [];
+    const target = (process.env.API_PROXY_TARGET ?? "http://localhost:5299").replace(/\/$/, "");
+    return [{ source: "/api/:path*", destination: `${target}/api/:path*` }];
+  },
+};
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
Next.js dev rewrites /api to API (fixes 404 on admin test-email when using same-origin). Adds handler and helper unit tests.

Made with [Cursor](https://cursor.com)