### PR TITLE
CI: integer coverage gates and portal page tests

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -99,8 +99,8 @@ jobs:
       - name: Checkout (for scripts consistency)
         uses: actions/checkout@v4
 
-      - name: Install jq and bc
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq jq bc
+      - name: Install jq
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq jq
 
       # --- Download artifacts from portal-ci + backend-ci ---
       - name: Download portal coverage
@@ -159,17 +159,20 @@ jobs:
             echo "::error::Backend coverage file not found"
             exit 1
           fi
-          LINE_RATE=$(grep -m1 -o 'line-rate="[^"]*"' "$COV_FILE" | cut -d'"' -f2)
-          BRANCH_RATE=$(grep -m1 -o 'branch-rate="[^"]*"' "$COV_FILE" | cut -d'"' -f2)
-          LINE_PCT=$(echo "$LINE_RATE * 100" | bc)
-          BRANCH_PCT=$(echo "$BRANCH_RATE * 100" | bc)
+          # Integer threshold: covered*100 >= valid*75 (avoids bc float quirks vs Cobertura rates)
+          LINE_COV=$(grep -m1 -o 'lines-covered="[0-9]*"' "$COV_FILE" | grep -o '[0-9]*')
+          LINE_VAL=$(grep -m1 -o 'lines-valid="[0-9]*"' "$COV_FILE" | grep -o '[0-9]*')
+          BRANCH_COV=$(grep -m1 -o 'branches-covered="[0-9]*"' "$COV_FILE" | grep -o '[0-9]*')
+          BRANCH_VAL=$(grep -m1 -o 'branches-valid="[0-9]*"' "$COV_FILE" | grep -o '[0-9]*')
+          LINE_PCT=$(awk -v c="$LINE_COV" -v v="$LINE_VAL" 'BEGIN { if (v+0 == 0) print 0; else printf "%.2f", 100*c/v }')
+          BRANCH_PCT=$(awk -v c="$BRANCH_COV" -v v="$BRANCH_VAL" 'BEGIN { if (v+0 == 0) print 0; else printf "%.2f", 100*c/v }')
           FAIL=0
-          if (( $(echo "$LINE_PCT < 75" | bc -l) )); then
-            echo "::error::Backend line coverage ${LINE_PCT}% is below 75% minimum"
+          if [ -z "$LINE_COV" ] || [ -z "$LINE_VAL" ] || [ "$LINE_VAL" -eq 0 ] || [ "$((LINE_COV * 100))" -lt "$((LINE_VAL * 75))" ]; then
+            echo "::error::Backend line coverage ${LINE_PCT}% is below 75% minimum (${LINE_COV}/${LINE_VAL})"
             FAIL=1
           fi
-          if (( $(echo "$BRANCH_PCT < 75" | bc -l) )); then
-            echo "::error::Backend branch coverage ${BRANCH_PCT}% is below 75% minimum"
+          if [ -z "$BRANCH_COV" ] || [ -z "$BRANCH_VAL" ] || [ "$BRANCH_VAL" -eq 0 ] || [ "$((BRANCH_COV * 100))" -lt "$((BRANCH_VAL * 75))" ]; then
+            echo "::error::Backend branch coverage ${BRANCH_PCT}% is below 75% minimum (${BRANCH_COV}/${BRANCH_VAL})"
             FAIL=1
           fi
           if [ $FAIL -eq 1 ]; then exit 1; fi
@@ -180,15 +183,19 @@ jobs:
             echo "::error::Portal coverage file not found"
             exit 1
           fi
+          LINE_COV=$(jq -r '.total.lines.covered' portal/coverage/coverage-summary.json)
+          LINE_TOT=$(jq -r '.total.lines.total' portal/coverage/coverage-summary.json)
+          BRANCH_COV=$(jq -r '.total.branches.covered' portal/coverage/coverage-summary.json)
+          BRANCH_TOT=$(jq -r '.total.branches.total' portal/coverage/coverage-summary.json)
           LINE_PCT=$(jq -r '.total.lines.pct' portal/coverage/coverage-summary.json)
           BRANCH_PCT=$(jq -r '.total.branches.pct' portal/coverage/coverage-summary.json)
           FAIL=0
-          if (( $(echo "$LINE_PCT < 75" | bc -l) )); then
-            echo "::error::Portal line coverage ${LINE_PCT}% is below 75% minimum"
+          if [ -z "$LINE_COV" ] || [ -z "$LINE_TOT" ] || [ "$LINE_TOT" = "null" ] || [ "$LINE_TOT" -eq 0 ] || [ "$((LINE_COV * 100))" -lt "$((LINE_TOT * 75))" ]; then
+            echo "::error::Portal line coverage ${LINE_PCT}% is below 75% minimum (${LINE_COV}/${LINE_TOT})"
             FAIL=1
           fi
-          if (( $(echo "$BRANCH_PCT < 75" | bc -l) )); then
-            echo "::error::Portal branch coverage ${BRANCH_PCT}% is below 75% minimum"
+          if [ -z "$BRANCH_COV" ] || [ -z "$BRANCH_TOT" ] || [ "$BRANCH_TOT" = "null" ] || [ "$BRANCH_TOT" -eq 0 ] || [ "$((BRANCH_COV * 100))" -lt "$((BRANCH_TOT * 75))" ]; then
+            echo "::error::Portal branch coverage ${BRANCH_PCT}% is below 75% minimum (${BRANCH_COV}/${BRANCH_TOT})"
             FAIL=1
           fi
           if [ $FAIL -eq 1 ]; then exit 1; fi

--- a/portal/src/app/[locale]/(auth)/accept-invite/page.test.tsx
+++ b/portal/src/app/[locale]/(auth)/accept-invite/page.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@/test/test-utils";
+import AcceptInvitePage from "./page";
+
+const mockReplace = vi.fn();
+const mockSetAuth = vi.fn();
+
+const authMock = {
+  login: mockSetAuth,
+  isAuthenticated: false,
+};
+
+vi.mock("@/context/AuthContext", () => ({
+  useAuth: () => authMock,
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams({ token: "from-query" }),
+}));
+
+const mockAcceptInvite = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api", () => ({
+  acceptCompanyAdminInvite: mockAcceptInvite,
+}));
+
+describe("AcceptInvitePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMock.isAuthenticated = false;
+  });
+
+  it("renders invite form with token from query string", async () => {
+    render(<AcceptInvitePage />);
+    const tokenInput = await screen.findByLabelText(/inviteToken/i);
+    expect(tokenInput).toHaveValue("from-query");
+    expect(screen.getByText("inviteTitle")).toBeInTheDocument();
+  });
+
+  it("shows password mismatch error", async () => {
+    render(<AcceptInvitePage />);
+    await screen.findByLabelText(/inviteToken/i);
+    fireEvent.change(screen.getByLabelText(/userName/i), { target: { value: "admin" } });
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: "secret12" } });
+    fireEvent.change(screen.getByLabelText(/confirmPassword/i), {
+      target: { value: "other12" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /inviteSubmit/i }));
+
+    await expect(screen.findByRole("alert")).resolves.toHaveTextContent("passwordMismatch");
+    expect(mockAcceptInvite).not.toHaveBeenCalled();
+  });
+
+  it("submits and signs in on success", async () => {
+    mockAcceptInvite.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "u1",
+        email: "a@b.com",
+        displayName: "Admin",
+        businessId: "B1",
+        customerMappingId: null,
+        jwtToken: "jwt-here",
+        roles: ["Admin"],
+      },
+    });
+
+    render(<AcceptInvitePage />);
+    await screen.findByLabelText(/inviteToken/i);
+    fireEvent.change(screen.getByLabelText(/userName/i), { target: { value: "admin" } });
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: "secret12" } });
+    fireEvent.change(screen.getByLabelText(/confirmPassword/i), {
+      target: { value: "secret12" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /inviteSubmit/i }));
+
+    await waitFor(() => {
+      expect(mockAcceptInvite).toHaveBeenCalledWith({
+        token: "from-query",
+        password: "secret12",
+        userName: "admin",
+      });
+    });
+    expect(mockSetAuth).toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("shows API error message when invite is invalid", async () => {
+    mockAcceptInvite.mockResolvedValueOnce({
+      success: false,
+      message: "Expired token",
+    });
+
+    render(<AcceptInvitePage />);
+    await screen.findByLabelText(/inviteToken/i);
+    fireEvent.change(screen.getByLabelText(/userName/i), { target: { value: "admin" } });
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: "secret12" } });
+    fireEvent.change(screen.getByLabelText(/confirmPassword/i), {
+      target: { value: "secret12" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /inviteSubmit/i }));
+
+    await expect(screen.findByRole("alert")).resolves.toHaveTextContent("Expired token");
+  });
+
+  it("shows inviteInvalid when API throws", async () => {
+    mockAcceptInvite.mockRejectedValueOnce(new Error("network"));
+
+    render(<AcceptInvitePage />);
+    await screen.findByLabelText(/inviteToken/i);
+    fireEvent.change(screen.getByLabelText(/userName/i), { target: { value: "admin" } });
+    fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: "secret12" } });
+    fireEvent.change(screen.getByLabelText(/confirmPassword/i), {
+      target: { value: "secret12" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /inviteSubmit/i }));
+
+    await expect(screen.findByRole("alert")).resolves.toHaveTextContent("inviteInvalid");
+  });
+
+  it("redirects to dashboard when already authenticated", async () => {
+    authMock.isAuthenticated = true;
+    render(<AcceptInvitePage />);
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+});

--- a/portal/src/app/[locale]/(protected)/company/courier-contracts/page.test.tsx
+++ b/portal/src/app/[locale]/(protected)/company/courier-contracts/page.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@/test/test-utils";
+import CourierContractsPage from "./page";
+
+const mockReplace = vi.fn();
+
+const mockGetContracts = vi.hoisted(() => vi.fn());
+const mockGetCatalog = vi.hoisted(() => vi.fn());
+const mockPutContracts = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api", () => ({
+  getCourierContracts: mockGetContracts,
+  getCourierCatalog: mockGetCatalog,
+  putCourierContracts: mockPutContracts,
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const stableT = vi.hoisted(() => {
+  const t = (key: string) => key;
+  return t;
+});
+
+vi.mock("next-intl", () => ({
+  // Stable reference: page useEffect depends on `t`; a new function each render causes an infinite loop.
+  useTranslations: () => stableT,
+}));
+
+const authMock = {
+  token: "jwt-token",
+  user: { roles: ["Admin"] as string[] },
+  isAuthenticated: true,
+  isLoading: false,
+};
+
+vi.mock("@/context/AuthContext", () => ({
+  useAuth: () => authMock,
+}));
+
+describe("CourierContractsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMock.token = "jwt-token";
+    authMock.user = { roles: ["Admin"] };
+    authMock.isAuthenticated = true;
+    authMock.isLoading = false;
+    mockGetContracts.mockResolvedValue([]);
+    mockGetCatalog.mockResolvedValue(["matkahuolto"]);
+    mockPutContracts.mockResolvedValue([]);
+  });
+
+  it("redirects to login when not authenticated", async () => {
+    authMock.isAuthenticated = false;
+    render(<CourierContractsPage />);
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("shows super admin message and no contract editor", async () => {
+    authMock.user = { roles: ["SuperAdmin"] };
+    render(<CourierContractsPage />);
+    expect(await screen.findByText("superAdminNoAccess")).toBeInTheDocument();
+    expect(mockGetContracts).not.toHaveBeenCalled();
+  });
+
+  it("shows empty state for admin when there are no contracts", async () => {
+    render(<CourierContractsPage />);
+    expect(await screen.findByText("emptyList")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("title");
+    expect(mockGetContracts).toHaveBeenCalledWith("jwt-token");
+    expect(mockGetCatalog).toHaveBeenCalledWith("jwt-token");
+  });
+
+  it("shows load error when contracts request fails", async () => {
+    mockGetContracts.mockRejectedValueOnce(new Error("server down"));
+    render(<CourierContractsPage />);
+    expect(await screen.findByRole("alert")).toHaveTextContent("server down");
+  });
+
+  it("shows read-only hint for non-admin users", async () => {
+    authMock.user = { roles: ["User"] };
+    mockGetContracts.mockResolvedValue([
+      { courierId: "dhl", contractId: "C-1", service: "Express" },
+    ]);
+    render(<CourierContractsPage />);
+    expect(await screen.findByText("readOnlyHint")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /addCourier/i })).not.toBeInTheDocument();
+    expect(await screen.findByText("dhl")).toBeInTheDocument();
+  });
+
+  it("saves contracts for admin", async () => {
+    mockGetContracts.mockImplementation(() =>
+      Promise.resolve([{ courierId: "matkahuolto", contractId: "", service: "" }])
+    );
+    mockPutContracts.mockResolvedValue([]);
+    render(<CourierContractsPage />);
+    const contractInput = await screen.findByPlaceholderText("contractIdPlaceholder");
+    fireEvent.change(contractInput, { target: { value: "AGR-99" } });
+    await waitFor(() => {
+      expect((contractInput as HTMLInputElement).value).toBe("AGR-99");
+    });
+    const saveBtn = await screen.findByText("save", { selector: "button" });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(mockPutContracts).toHaveBeenCalledWith("jwt-token", [
+        { courierId: "matkahuolto", contractId: "AGR-99", service: undefined },
+      ]);
+    });
+  });
+
+  it("shows catalog unavailable when catalog fetch fails for admin", async () => {
+    mockGetCatalog.mockRejectedValueOnce(new Error("catalog down"));
+    render(<CourierContractsPage />);
+    await screen.findByText("catalogUnavailable");
+  });
+});

--- a/portal/src/app/[locale]/page.test.tsx
+++ b/portal/src/app/[locale]/page.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@/test/test-utils";
+import LocaleRootPage from "./page";
+
+const mockReplace = vi.fn();
+
+vi.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const authMock = {
+  isAuthenticated: false,
+  isLoading: true,
+};
+
+vi.mock("@/context/AuthContext", () => ({
+  useAuth: () => authMock,
+}));
+
+describe("LocaleRootPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMock.isAuthenticated = false;
+    authMock.isLoading = true;
+  });
+
+  it("shows redirecting text while loading", () => {
+    authMock.isLoading = true;
+    render(<LocaleRootPage />);
+    expect(screen.getByText("redirecting")).toBeInTheDocument();
+  });
+
+  it("redirects to dashboard when authenticated", async () => {
+    authMock.isLoading = false;
+    authMock.isAuthenticated = true;
+    render(<LocaleRootPage />);
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("redirects to login when not authenticated", async () => {
+    authMock.isLoading = false;
+    authMock.isAuthenticated = false;
+    render(<LocaleRootPage />);
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/login");
+    });
+  });
+});

--- a/portal/vitest.config.ts
+++ b/portal/vitest.config.ts
@@ -19,7 +19,6 @@ export default defineConfig({
         "src/app/layout.tsx",
         "src/app/providers.tsx",
         "src/app/**/layout.tsx",
-        "src/app/[locale]/page.tsx",
         "src/app/**/forgot-password/**",
         "src/app/**/reset-password/**",
         "src/app/**/manage/**",


### PR DESCRIPTION
Aligns PR Validation with integer line/branch thresholds (no bc). Adds Vitest coverage for locale root, accept-invite, and courier-contracts pages; removes invalid \[locale]\ coverage exclude.

After merge into \development\, promote via separate PRs: \development\ → \main\ and \development\ → \master\ per release policy.

Made with [Cursor](https://cursor.com)