### PR TITLE
Promote development to master (SMTP deploy + sync)

### DIFF
--- a/.github/workflows/docker-deploy-mac.yml
+++ b/.github/workflows/docker-deploy-mac.yml
@@ -121,6 +121,12 @@ jobs:
           Jwt__SigningKey: ${{ secrets.JWT__SIGNING_KEY }}
           CORS__PORTAL_ORIGIN: ${{ secrets.CORS__PORTAL_ORIGIN }}
           NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
+          Smtp__Host: ${{ secrets.Smtp__Host }}
+          Smtp__Port: ${{ secrets.Smtp__Port }}
+          Smtp__UseSsl: ${{ secrets.Smtp__UseSsl }}
+          Smtp__UserName: ${{ secrets.Smtp__UserName }}
+          Smtp__Password: ${{ secrets.Smtp__Password }}
+          Smtp__FromAddress: ${{ secrets.Smtp__FromAddress }}
         run: |
           set -e
           export COMPOSE_HTTP_TIMEOUT="${COMPOSE_HTTP_TIMEOUT:-600}"

--- a/docker-compose.one.yml
+++ b/docker-compose.one.yml
@@ -26,6 +26,13 @@ services:
       Cors__PortalOrigin: ${CORS__PORTAL_ORIGIN:-http://localhost:3000}
       # Optional: starts in-container ngrok (token from GitHub Actions secret or .env)
       NGROK_AUTHTOKEN: ${NGROK_AUTHTOKEN:-}
+      # SMTP (set via GitHub Secrets synced from .env, or local compose --env-file)
+      Smtp__Host: ${Smtp__Host:-}
+      Smtp__Port: ${Smtp__Port:-587}
+      Smtp__UseSsl: ${Smtp__UseSsl:-true}
+      Smtp__UserName: ${Smtp__UserName:-}
+      Smtp__Password: ${Smtp__Password:-}
+      Smtp__FromAddress: ${Smtp__FromAddress:-}
 
 volumes:
   cargohub_data:


### PR DESCRIPTION
Brings \master\ up to date with \development\, including merged PR #158 (SMTP settings in Mac deploy / docker-compose.one.yml).

Made with [Cursor](https://cursor.com)