### PR TITLE
fix(smtp): MailKit for Gmail STARTTLS and auth

### DIFF
--- a/CargoHub.Infrastructure/CargoHub.Infrastructure.csproj
+++ b/CargoHub.Infrastructure/CargoHub.Infrastructure.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MailKit" Version="4.9.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />

--- a/CargoHub.Infrastructure/Couriers/SmtpEmailSender.cs
+++ b/CargoHub.Infrastructure/Couriers/SmtpEmailSender.cs
@@ -1,12 +1,14 @@
-using System.Net;
-using System.Net.Mail;
 using CargoHub.Application.Couriers;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
 using Microsoft.Extensions.Options;
 
 namespace CargoHub.Infrastructure.Couriers;
 
 /// <summary>
 /// Sends email via SMTP. Configure via SmtpOptions (e.g. from appsettings or env, aligned with booking-backend .env SMTP_*).
+/// Uses MailKit so STARTTLS (port 587) and Gmail behave reliably; <see cref="System.Net.Mail.SmtpClient"/> is often flaky here.
 /// </summary>
 public sealed class SmtpEmailSender : IEmailSender
 {
@@ -27,23 +29,52 @@ public sealed class SmtpEmailSender : IEmailSender
                 "SmtpOptions.Host is not configured. Set Smtp:Host in appsettings, or environment variable Smtp__Host, " +
                 "or legacy SMTP_SERVER_EMAIL / SMTP_HOST. If you use a .env file, remove Smtp__Host when unused (an empty value overrides appsettings).");
 
-        using var client = new SmtpClient(_options.Host, _options.Port);
-        client.EnableSsl = _options.UseSsl;
-        if (!string.IsNullOrEmpty(_options.UserName))
-            client.Credentials = new NetworkCredential(_options.UserName, _options.Password);
-
         var from = _options.FromAddress;
         if (string.IsNullOrEmpty(from))
             throw new InvalidOperationException("SmtpOptions.FromAddress is not configured. Set Smtp:FromAddress in appsettings or environment.");
-        using var message = new MailMessage(from, to, subject, htmlBody) { IsBodyHtml = true };
+
+        var hasUser = !string.IsNullOrWhiteSpace(_options.UserName);
+        if (hasUser && string.IsNullOrEmpty(_options.Password))
+            throw new InvalidOperationException(
+                "SmtpOptions.Password is empty but UserName is set. Gmail and most providers require a password (for Google, use an App Password with 2-Step Verification, not your normal login password). " +
+                "If you deploy with GitHub Actions, ensure the Smtp__Password secret is set.");
+
+        var message = new MimeMessage();
+        message.From.Add(MailboxAddress.Parse(from));
+        message.To.Add(MailboxAddress.Parse(to));
+        message.Subject = subject;
+
+        var builder = new BodyBuilder { HtmlBody = htmlBody };
         foreach (var a in attachments)
         {
             if (a.Content.Length == 0) continue;
-            var stream = new MemoryStream(a.Content);
-            message.Attachments.Add(new Attachment(stream, a.FileName, a.ContentType));
+            var ct = ContentType.Parse(a.ContentType);
+            builder.Attachments.Add(a.FileName, a.Content, ct);
         }
 
-        await client.SendMailAsync(message, cancellationToken);
+        message.Body = builder.ToMessageBody();
+
+        using var client = new SmtpClient();
+        var secure = ResolveSecureSocketOptions();
+        await client.ConnectAsync(_options.Host, _options.Port, secure, cancellationToken);
+
+        if (hasUser)
+            await client.AuthenticateAsync(_options.UserName!, _options.Password ?? string.Empty, cancellationToken);
+
+        await client.SendAsync(message, cancellationToken);
+        await client.DisconnectAsync(true, cancellationToken);
+    }
+
+    private SecureSocketOptions ResolveSecureSocketOptions()
+    {
+        // 465 = implicit TLS; 587/25 typically STARTTLS when UseSsl is true
+        if (_options.Port == 465 && _options.UseSsl)
+            return SecureSocketOptions.SslOnConnect;
+
+        if (_options.UseSsl)
+            return SecureSocketOptions.StartTls;
+
+        return SecureSocketOptions.None;
     }
 }
 


### PR DESCRIPTION
Replaces \System.Net.Mail.SmtpClient\ with MailKit for reliable STARTTLS on port 587 and Gmail. Fails fast with a clear message when username is set but password is empty (common with missing GitHub secrets / App Password).

Made with [Cursor](https://cursor.com)