### PR TITLE
fix(portal): invite links use Portal URL or CORS origin

### DIFF
--- a/CargoHub.Api/appsettings.json
+++ b/CargoHub.Api/appsettings.json
@@ -14,6 +14,10 @@
     }
   },
   "AllowedHosts": "*",
+  "Portal": {
+    "PublicBaseUrl": "",
+    "CompanyAdminFallbackEmailDomain": "example.com"
+  },
   "Branding": {
     "AppName": "Portal",
     "LogoUrl": "",

--- a/CargoHub.Infrastructure/Company/CompanyAdminInviteIssuer.cs
+++ b/CargoHub.Infrastructure/Company/CompanyAdminInviteIssuer.cs
@@ -4,6 +4,7 @@ using CargoHub.Domain.Companies;
 using CargoHub.Infrastructure.Options;
 using CargoHub.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -17,6 +18,7 @@ public sealed class CompanyAdminInviteIssuer : ICompanyAdminInviteIssuer
     private readonly ICompanyAdminInviteRepository _invites;
     private readonly IEmailSender _emailSender;
     private readonly IOptions<PortalPublicOptions> _portal;
+    private readonly IConfiguration _configuration;
     private readonly ApplicationDbContext _db;
     private readonly ILogger<CompanyAdminInviteIssuer> _logger;
 
@@ -24,12 +26,14 @@ public sealed class CompanyAdminInviteIssuer : ICompanyAdminInviteIssuer
         ICompanyAdminInviteRepository invites,
         IEmailSender emailSender,
         IOptions<PortalPublicOptions> portal,
+        IConfiguration configuration,
         ApplicationDbContext db,
         ILogger<CompanyAdminInviteIssuer> logger)
     {
         _invites = invites;
         _emailSender = emailSender;
         _portal = portal;
+        _configuration = configuration;
         _db = db;
         _logger = logger;
     }
@@ -95,7 +99,7 @@ public sealed class CompanyAdminInviteIssuer : ICompanyAdminInviteIssuer
 
         await _invites.AddAsync(invite, cancellationToken);
 
-        var baseUrl = _portal.Value.PublicBaseUrl.TrimEnd('/');
+        var baseUrl = PortalPublicBaseUrlResolver.Resolve(_portal.Value, _configuration);
         var link = $"{baseUrl}/en/accept-invite?token={Uri.EscapeDataString(raw)}";
 
         var company = await _db.Companies.AsNoTracking().FirstOrDefaultAsync(c => c.Id == companyId, cancellationToken);

--- a/CargoHub.Infrastructure/Options/PortalPublicBaseUrlResolver.cs
+++ b/CargoHub.Infrastructure/Options/PortalPublicBaseUrlResolver.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Configuration;
+
+namespace CargoHub.Infrastructure.Options;
+
+/// <summary>
+/// Resolves the public portal origin for absolute links in emails (invites, etc.).
+/// Prefer <see cref="PortalPublicOptions.PublicBaseUrl"/>; fall back to CORS portal settings.
+/// </summary>
+public static class PortalPublicBaseUrlResolver
+{
+    public static string Resolve(PortalPublicOptions portal, IConfiguration configuration)
+    {
+        var fromPortal = portal.PublicBaseUrl?.Trim();
+        if (!string.IsNullOrEmpty(fromPortal))
+            return fromPortal.TrimEnd('/');
+
+        var corsOrigin = configuration["Cors:PortalOrigin"]?.Trim();
+        if (!string.IsNullOrEmpty(corsOrigin))
+            return corsOrigin.TrimEnd('/');
+
+        var origins = configuration.GetSection("Cors:PortalOrigins").Get<string[]>();
+        var first = origins?.FirstOrDefault(s => !string.IsNullOrWhiteSpace(s))?.Trim();
+        if (!string.IsNullOrEmpty(first))
+            return first.TrimEnd('/');
+
+        return "http://localhost:3000";
+    }
+}

--- a/CargoHub.Infrastructure/Options/PortalPublicOptions.cs
+++ b/CargoHub.Infrastructure/Options/PortalPublicOptions.cs
@@ -7,8 +7,8 @@ public sealed class PortalPublicOptions
 {
     public const string SectionName = "Portal";
 
-    /// <summary>Origin of the Next.js portal (no trailing slash), e.g. https://app.example.com</summary>
-    public string PublicBaseUrl { get; set; } = "http://localhost:3000";
+    /// <summary>Origin of the Next.js portal (no trailing slash), e.g. https://app.example.com. When empty, CORS portal origin is used.</summary>
+    public string PublicBaseUrl { get; set; } = "";
 
     /// <summary>Domain for fallback admin invite when Super Admin does not set an email.</summary>
     public string CompanyAdminFallbackEmailDomain { get; set; } = "example.com";

--- a/CargoHub.Tests/PortalPublicUrl/PortalPublicBaseUrlResolverTests.cs
+++ b/CargoHub.Tests/PortalPublicUrl/PortalPublicBaseUrlResolverTests.cs
@@ -1,0 +1,54 @@
+using CargoHub.Infrastructure.Options;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace CargoHub.Tests.PortalPublicUrl;
+
+public class PortalPublicBaseUrlResolverTests
+{
+    private static IConfiguration Config(params (string Key, string Value)[] pairs)
+    {
+        var dict = pairs.ToDictionary(p => p.Key, p => p.Value);
+        return new ConfigurationBuilder().AddInMemoryCollection(dict!).Build();
+    }
+
+    [Fact]
+    public void Resolve_UsesPublicBaseUrl_WhenSet()
+    {
+        var portal = new PortalPublicOptions { PublicBaseUrl = "https://app.example.com/" };
+        var url = PortalPublicBaseUrlResolver.Resolve(portal, Config());
+        Assert.Equal("https://app.example.com", url);
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToCorsPortalOrigin_WhenPublicBaseUrlEmpty()
+    {
+        var portal = new PortalPublicOptions { PublicBaseUrl = "" };
+        var cfg = Config(("Cors:PortalOrigin", "https://portal.prod.example/"));
+        var url = PortalPublicBaseUrlResolver.Resolve(portal, cfg);
+        Assert.Equal("https://portal.prod.example", url);
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToFirstPortalOrigin_WhenOthersEmpty()
+    {
+        var portal = new PortalPublicOptions { PublicBaseUrl = "  " };
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Cors:PortalOrigins:0"] = "",
+                ["Cors:PortalOrigins:1"] = "https://first-valid.example"
+            })
+            .Build();
+        var url = PortalPublicBaseUrlResolver.Resolve(portal, cfg);
+        Assert.Equal("https://first-valid.example", url);
+    }
+
+    [Fact]
+    public void Resolve_DefaultsToLocalhost_WhenNothingConfigured()
+    {
+        var portal = new PortalPublicOptions { PublicBaseUrl = "" };
+        var url = PortalPublicBaseUrlResolver.Resolve(portal, Config());
+        Assert.Equal("http://localhost:3000", url);
+    }
+}


### PR DESCRIPTION
## Summary
Company admin invitation emails used the default localhost URL when \Portal:PublicBaseUrl\ was unset in production. This adds a resolver that prefers \Portal:PublicBaseUrl\, then \Cors:PortalOrigin\, then the first \Cors:PortalOrigins\ entry, and documents the \Portal\ section in \ppsettings.json\.

## Deployment
Set \Portal__PublicBaseUrl\ (and/or your public portal in CORS) on the hosted API so invite links match your portal hostname.

## Testing
- \dotnet test\ (includes \PortalPublicBaseUrlResolverTests\)


Made with [Cursor](https://cursor.com)