### PR TITLE
fix(portal): Docker build — mapInviteError null-safe errorCode

### DIFF
--- a/portal/src/app/[locale]/(auth)/accept-invite/page.tsx
+++ b/portal/src/app/[locale]/(auth)/accept-invite/page.tsx
@@ -37,7 +37,7 @@ function AcceptInviteForm() {
 
   const hasToken = token.trim().length > 0;
 
-  function mapInviteError(errorCode: string | undefined): string {
+  function mapInviteError(errorCode: string | null | undefined): string {
     if (errorCode === "InviteEmailRequired") return t("inviteEmailRequired");
     if (errorCode === "InviteEmailMismatch") return t("inviteEmailMismatch");
     if (errorCode === "InviteTokenRequired") return t("inviteMissingLink");


### PR DESCRIPTION
CI Docker \
ext build\ failed: \mapInviteError\ expected \string | undefined\ but \LoginResult.errorCode\ is \string | null | undefined\. Widen the parameter type.

Made with [Cursor](https://cursor.com)