### PR TITLE
chore(branding): default navbar name CargoHub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,7 @@ Courier__HameenTavarataxi__CarrierEmail=
 Courier__HameenTavarataxi__TestEmail=
 
 # ---- Branding (optional, usually non-secret) ----
-# Branding__AppName=Portal
+# Branding__AppName=CargoHub
 # Branding__LogoUrl=
 # Branding__PrimaryColor=
 # Branding__SecondaryColor=

--- a/CargoHub.Api/Controllers/PortalController.cs
+++ b/CargoHub.Api/Controllers/PortalController.cs
@@ -84,7 +84,7 @@ public class PortalController : ControllerBase
     {
         return Ok(new BrandingResponse
         {
-            AppName = _branding.AppName ?? "Portal",
+            AppName = _branding.AppName ?? "CargoHub",
             LogoUrl = _branding.LogoUrl ?? "",
             PrimaryColor = _branding.PrimaryColor ?? "",
             SecondaryColor = _branding.SecondaryColor ?? ""

--- a/CargoHub.Api/appsettings.Development.json
+++ b/CargoHub.Api/appsettings.Development.json
@@ -27,7 +27,7 @@
     }
   },
   "Branding": {
-    "AppName": "Portal",
+    "AppName": "CargoHub",
     "LogoUrl": "",
     "PrimaryColor": "",
     "SecondaryColor": "",

--- a/CargoHub.Api/appsettings.json
+++ b/CargoHub.Api/appsettings.json
@@ -19,7 +19,7 @@
     "CompanyAdminFallbackEmailDomain": "example.com"
   },
   "Branding": {
-    "AppName": "Portal",
+    "AppName": "CargoHub",
     "LogoUrl": "",
     "PrimaryColor": "",
     "SecondaryColor": "",

--- a/portal/messages/da.json
+++ b/portal/messages/da.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "appName": "Portal",
+    "appName": "CargoHub",
     "loading": "Indlæser…",
     "redirecting": "Omdirigerer…",
     "signOut": "Log ud",

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "appName": "Portal",
+    "appName": "CargoHub",
     "loading": "Loading…",
     "redirecting": "Redirecting…",
     "signOut": "Sign out",

--- a/portal/messages/fi.json
+++ b/portal/messages/fi.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "appName": "Portal",
+    "appName": "CargoHub",
     "loading": "Ladataan…",
     "redirecting": "Ohjataan…",
     "signOut": "Kirjaudu ulos",

--- a/portal/messages/is.json
+++ b/portal/messages/is.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "appName": "Portal",
+    "appName": "CargoHub",
     "loading": "Hleður…",
     "redirecting": "Endurbeini…",
     "signOut": "Skrá út",

--- a/portal/messages/no.json
+++ b/portal/messages/no.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "appName": "Portal",
+    "appName": "CargoHub",
     "loading": "Laster…",
     "redirecting": "Omdirigerer…",
     "signOut": "Logg ut",

--- a/portal/messages/sv.json
+++ b/portal/messages/sv.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "appName": "Portal",
+    "appName": "CargoHub",
     "loading": "Laddar…",
     "redirecting": "Omdirigerar…",
     "signOut": "Logga ut",

--- a/portal/src/app/layout.tsx
+++ b/portal/src/app/layout.tsx
@@ -13,7 +13,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Portal",
+  title: "CargoHub",
   description: "Booking portal",
 };
 

--- a/portal/src/context/BrandingContext.tsx
+++ b/portal/src/context/BrandingContext.tsx
@@ -5,7 +5,7 @@ import type { BrandingResponse } from '@/lib/api';
 import { getBranding } from '@/lib/api';
 
 const defaultBranding: BrandingResponse = {
-  appName: 'Portal',
+  appName: 'CargoHub',
   logoUrl: '',
   primaryColor: '',
   secondaryColor: '',
@@ -58,7 +58,7 @@ export function BrandingDocumentHead() {
 
   useEffect(() => {
     if (typeof document === 'undefined') return;
-    const title = branding.appName ? `${branding.appName}` : 'Portal';
+    const title = branding.appName ? `${branding.appName}` : 'CargoHub';
     document.title = title;
     let meta = document.querySelector('meta[name="description"]');
     if (!meta) {


### PR DESCRIPTION
## Summary
- \Branding:AppName\ → CargoHub in appsettings (base + Development).
- GET \/api/v1/portal/branding\ fallback when AppName unset.
- Portal: default branding context, root layout metadata, all locale \ppName\.
- \.env.example\ comment for \Branding__AppName\.

Made with [Cursor](https://cursor.com)