### PR TITLE
feat(dashboard): heatmap tooltips, weekday averages, chart layout

### DIFF
--- a/CargoHub.Application/Bookings/Dtos/DashboardStatsDto.cs
+++ b/CargoHub.Application/Bookings/Dtos/DashboardStatsDto.cs
@@ -30,6 +30,12 @@ public sealed class DashboardBookingStatsDto
     /// <summary>Current UTC month, one bucket per calendar day (for calendar heatmap).</summary>
     public List<DailyCountDto> BookingsPerDayCurrentMonth { get; set; } = new();
 
+    /// <summary>Non-draft bookings per calendar day in the heatmap month (for tooltips alongside scope).</summary>
+    public List<DailyCountDto> CompletedBookingsPerDayCurrentMonth { get; set; } = new();
+
+    /// <summary>Draft bookings per calendar day in the heatmap month.</summary>
+    public List<DailyCountDto> DraftsPerDayCurrentMonth { get; set; } = new();
+
     public KpiExtendedDto Kpi { get; set; } = new();
 
     /// <summary>Hours from booking creation to Delivered milestone (when available).</summary>

--- a/CargoHub.Infrastructure/Persistence/BookingRepository.Dashboard.cs
+++ b/CargoHub.Infrastructure/Persistence/BookingRepository.Dashboard.cs
@@ -97,6 +97,19 @@ public sealed partial class BookingRepository
         }
 
         var calendarMonth = BuildBookingsPerDayForMonth(rows, calY, calM);
+        var completedMonthTask = BuildBookingCountsPerCalendarMonthAsync(
+            forCustomer.Where(b => !b.IsDraft),
+            calY,
+            calM,
+            cancellationToken);
+        var draftsMonthTask = BuildBookingCountsPerCalendarMonthAsync(
+            forCustomer.Where(b => b.IsDraft),
+            calY,
+            calM,
+            cancellationToken);
+        await Task.WhenAll(completedMonthTask, draftsMonthTask).ConfigureAwait(false);
+        var completedCalendarMonth = await completedMonthTask.ConfigureAwait(false);
+        var draftsCalendarMonth = await draftsMonthTask.ConfigureAwait(false);
         var delivery = await BuildDeliveryTimeDistributionAsync(baseQuery, cancellationToken);
         var exceptionHeat = await BuildExceptionHeatmapAsync(forCustomer, normalizedScope, cancellationToken);
 
@@ -113,6 +126,8 @@ public sealed partial class BookingRepository
             LaneSankey = sankey,
             BookingsPerDayLast30 = daily,
             BookingsPerDayCurrentMonth = calendarMonth,
+            CompletedBookingsPerDayCurrentMonth = completedCalendarMonth,
+            DraftsPerDayCurrentMonth = draftsCalendarMonth,
             Kpi = new KpiExtendedDto
             {
                 AvgPerDayLast30 = Math.Round(avgPerDayLast30, 2),
@@ -233,22 +248,56 @@ public sealed partial class BookingRepository
     private static List<DailyCountDto> BuildBookingsPerDayForMonth(List<DashboardRow> rows, int year, int month)
     {
         var daysInMonth = DateTime.DaysInMonth(year, month);
+        var dict = new Dictionary<string, int>();
+        foreach (var r in rows)
+        {
+            var key = DateOnly.FromDateTime(r.CreatedAtUtc).ToString("yyyy-MM-dd");
+            if (!IsDateInUtcMonth(key, year, month))
+                continue;
+            dict.TryGetValue(key, out var n);
+            dict[key] = n + 1;
+        }
+
+        return BuildDailyListForMonth(year, month, dict);
+    }
+
+    private static bool IsDateInUtcMonth(string yyyyMmDd, int year, int month)
+    {
+        if (!DateOnly.TryParse(yyyyMmDd, out var d))
+            return false;
+        return d.Year == year && d.Month == month;
+    }
+
+    private static List<DailyCountDto> BuildDailyListForMonth(int year, int month, Dictionary<string, int> countsByDate)
+    {
+        var daysInMonth = DateTime.DaysInMonth(year, month);
         var list = new List<DailyCountDto>();
         for (var d = 1; d <= daysInMonth; d++)
         {
             var date = new DateOnly(year, month, d);
-            list.Add(new DailyCountDto { Date = date.ToString("yyyy-MM-dd"), Count = 0 });
-        }
-
-        var idx = list.ToDictionary(x => x.Date, x => x);
-        foreach (var r in rows)
-        {
-            var key = DateOnly.FromDateTime(r.CreatedAtUtc).ToString("yyyy-MM-dd");
-            if (idx.TryGetValue(key, out var cell))
-                cell.Count++;
+            var key = date.ToString("yyyy-MM-dd");
+            list.Add(new DailyCountDto { Date = key, Count = countsByDate.GetValueOrDefault(key) });
         }
 
         return list;
+    }
+
+    private static async Task<List<DailyCountDto>> BuildBookingCountsPerCalendarMonthAsync(
+        IQueryable<Booking> query,
+        int year,
+        int month,
+        CancellationToken cancellationToken)
+    {
+        var monthStart = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var monthEnd = monthStart.AddMonths(1);
+        var groups = await query
+            .Where(b => b.CreatedAtUtc >= monthStart && b.CreatedAtUtc < monthEnd)
+            .GroupBy(b => DateOnly.FromDateTime(b.CreatedAtUtc))
+            .Select(g => new { Date = g.Key, Count = g.Count() })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var dict = groups.ToDictionary(x => x.Date.ToString("yyyy-MM-dd"), x => x.Count);
+        return BuildDailyListForMonth(year, month, dict);
     }
 
     private async Task<DeliveryTimeDistributionDto> BuildDeliveryTimeDistributionAsync(

--- a/CargoHub.Tests/Integration/BookingRepositoryTestDbTests.cs
+++ b/CargoHub.Tests/Integration/BookingRepositoryTestDbTests.cs
@@ -266,6 +266,8 @@ public class BookingRepositoryTestDbTests : IDisposable
 
         var stats = await repo.GetDashboardStatsAsync(customerId, null, 2024, 2, default);
         Assert.Equal(29, stats.BookingsPerDayCurrentMonth.Count);
+        Assert.Equal(29, stats.CompletedBookingsPerDayCurrentMonth.Count);
+        Assert.Equal(29, stats.DraftsPerDayCurrentMonth.Count);
     }
 
     [Fact]

--- a/portal/messages/da.json
+++ b/portal/messages/da.json
@@ -114,6 +114,8 @@
       "last7DaysTitle": "Seneste dagsaktivitet",
       "courierShareTitle": "Andel pr. transportør",
       "benchmarkAvg30": "30-dages gennemsnit",
+      "sameWeekdayAvg30": "Gennemsnit for samme ugedag (30 dage)",
+      "heatmapCellTooltip": "{date}: {bookingCount} bookinger, {draftCount} kladder",
       "otherCouriers": "Øvrige",
       "bookings": "Bookinger",
       "byCourier": "Per speditør",

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -116,6 +116,8 @@
       "last7DaysTitle": "Recent daily activity",
       "courierShareTitle": "Share by carrier",
       "benchmarkAvg30": "30-day average",
+      "sameWeekdayAvg30": "Same weekday average (30 days)",
+      "heatmapCellTooltip": "{date}: {bookingCount} bookings, {draftCount} drafts",
       "otherCouriers": "Other",
       "bookings": "Bookings",
       "byCourier": "By courier",

--- a/portal/messages/fi.json
+++ b/portal/messages/fi.json
@@ -115,6 +115,8 @@
       "last7DaysTitle": "Viime päivien aktiivisuus",
       "courierShareTitle": "Jakauma kuljettajittain",
       "benchmarkAvg30": "30 pv keskiarvo",
+      "sameWeekdayAvg30": "Saman viikonpäivän keskiarvo (30 pv)",
+      "heatmapCellTooltip": "{date}: {bookingCount} varausta, {draftCount} luonnosta",
       "otherCouriers": "Muut",
       "bookings": "Varaukset",
       "byCourier": "Kuljetusliikkeittäin",

--- a/portal/messages/is.json
+++ b/portal/messages/is.json
@@ -114,6 +114,8 @@
       "last7DaysTitle": "Dagleg virkni nýleg",
       "courierShareTitle": "Hlutfall eftir flutningsaðila",
       "benchmarkAvg30": "30 daga meðaltal",
+      "sameWeekdayAvg30": "Meðaltal fyrir sama vikudag (30 dagar)",
+      "heatmapCellTooltip": "{date}: {bookingCount} bókanir, {draftCount} drög",
       "otherCouriers": "Aðrir",
       "bookings": "Bókanir",
       "byCourier": "Eftir sendiferð",

--- a/portal/messages/no.json
+++ b/portal/messages/no.json
@@ -114,6 +114,8 @@
       "last7DaysTitle": "Siste dagsaktivitet",
       "courierShareTitle": "Andel per transportør",
       "benchmarkAvg30": "30-dagers snitt",
+      "sameWeekdayAvg30": "Snitt for samme ukedag (30 dager)",
+      "heatmapCellTooltip": "{date}: {bookingCount} bookinger, {draftCount} utkast",
       "otherCouriers": "Øvrige",
       "bookings": "Bookinger",
       "byCourier": "Per speditør",

--- a/portal/messages/sv.json
+++ b/portal/messages/sv.json
@@ -114,6 +114,8 @@
       "last7DaysTitle": "Senaste dagsaktivitet",
       "courierShareTitle": "Andel per transportör",
       "benchmarkAvg30": "30-dagars medel",
+      "sameWeekdayAvg30": "Medel för samma veckodag (30 dagar)",
+      "heatmapCellTooltip": "{date}: {bookingCount} bokningar, {draftCount} utkast",
       "otherCouriers": "Övriga",
       "bookings": "Bokningar",
       "byCourier": "Per speditör",

--- a/portal/src/app/[locale]/(protected)/dashboard/page.tsx
+++ b/portal/src/app/[locale]/(protected)/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   getDashboardStats,
+  type DailyCount,
   type DashboardScope,
   type DashboardStats,
 } from "@/lib/api";
@@ -253,12 +254,27 @@ export default function DashboardPage() {
       stats.bookingsPerDayLast30,
       themeSlice,
       tStats("bookings"),
-      tStats("benchmarkAvg30"),
+      tStats("sameWeekdayAvg30"),
       chartTheme.chart[0],
       benchColor,
       dayLabels,
     );
   }, [stats, themeSlice, chartTheme.chart, tStats, dayLabels]);
+
+  const heatmapTooltipSeries = useMemo(() => {
+    if (!stats) return { completed: [] as DailyCount[], drafts: [] as DailyCount[] };
+    const completed =
+      stats.completedBookingsPerDayCurrentMonth ??
+      (scope === "all" ? stats.bookingsPerDayCurrentMonth : []);
+    const drafts =
+      stats.draftsPerDayCurrentMonth ?? (scope === "drafts" ? stats.bookingsPerDayCurrentMonth : []);
+    return { completed, drafts };
+  }, [stats, scope]);
+
+  const formatHeatmapCellTooltip = useCallback(
+    (p: { date: string; bookingCount: number; draftCount: number }) => tStats("heatmapCellTooltip", p),
+    [tStats],
+  );
 
   const courierPieOption = useMemo(() => {
     if (!stats?.byCourier.length) return null;
@@ -433,8 +449,8 @@ export default function DashboardPage() {
               <div className="grid gap-6 lg:grid-cols-2">
                 <ChartPanel title={tStats("last7DaysTitle")}>
                   {last7GroupedOption ? (
-                    <div className="h-56 w-full min-h-[224px]">
-                      <ThemedECharts option={last7GroupedOption} height={224} />
+                    <div className="h-60 w-full min-h-[240px]">
+                      <ThemedECharts option={last7GroupedOption} height={240} />
                     </div>
                   ) : (
                     <p className="text-sm text-muted-foreground">{tStats("noData")}</p>
@@ -548,13 +564,15 @@ export default function DashboardPage() {
                     <div className="w-full pt-1">
                       <BookingCalendarHeatmapGrid
                         daily={stats.bookingsPerDayCurrentMonth}
+                        completedDaily={heatmapTooltipSeries.completed}
+                        draftsDaily={heatmapTooltipSeries.drafts}
                         targetYear={heatmapUtc.year}
                         targetMonth={heatmapUtc.month}
                         dowLabels={mondayFirstDowLabels}
                         weekLabel={(week, isoYear) =>
                           tStats("heatmapIsoWeekWithYear", { week, year: isoYear })
                         }
-                        bookingsLabel={tStats("bookings")}
+                        formatCellTooltip={formatHeatmapCellTooltip}
                       />
                     </div>
                   </ChartPanel>

--- a/portal/src/components/dashboard/BookingCalendarHeatmap.tsx
+++ b/portal/src/components/dashboard/BookingCalendarHeatmap.tsx
@@ -44,22 +44,30 @@ function cellSurfaceClass(
 
 export function BookingCalendarHeatmapGrid({
   daily,
+  completedDaily,
+  draftsDaily,
   targetYear,
   targetMonth,
   dowLabels,
   weekLabel,
-  bookingsLabel,
+  formatCellTooltip,
 }: {
   daily: DailyBookingCell[];
+  /** Non-draft counts per day (heatmap month); used for tooltips. */
+  completedDaily: DailyBookingCell[];
+  /** Draft counts per day (heatmap month); used for tooltips. */
+  draftsDaily: DailyBookingCell[];
   /** Calendar year of the month shown (must match month selector and API request). */
   targetYear: number;
   /** 1–12, must match month selector and API request. */
   targetMonth: number;
   dowLabels: string[];
   weekLabel: (isoWeek: number, isoWeekYear: number) => string;
-  bookingsLabel: string;
+  formatCellTooltip: (p: { date: string; bookingCount: number; draftCount: number }) => string;
 }) {
   const { weeks, maxCount } = buildBookingMonthGrid(daily, targetYear, targetMonth);
+  const completedMap = new Map(completedDaily.map((x) => [x.date, x.count]));
+  const draftsMap = new Map(draftsDaily.map((x) => [x.date, x.count]));
 
   return (
     <div
@@ -84,7 +92,11 @@ export function BookingCalendarHeatmapGrid({
             {weekLabel(w.isoWeek, w.isoWeekYear)}
           </div>
           {w.cells.map((c) => {
-            const title = `${c.date}: ${c.count} ${bookingsLabel}`;
+            const bookingCount = completedMap.get(c.date) ?? 0;
+            const draftCount = draftsMap.get(c.date) ?? 0;
+            const title = c.inTargetMonth
+              ? formatCellTooltip({ date: c.date, bookingCount, draftCount })
+              : c.date;
             return (
               <div
                 key={c.date}

--- a/portal/src/lib/api.ts
+++ b/portal/src/lib/api.ts
@@ -1181,6 +1181,10 @@ export type DashboardStats = {
   laneSankey: SankeyGraph;
   bookingsPerDayLast30: DailyCount[];
   bookingsPerDayCurrentMonth: DailyCount[];
+  /** Non-draft counts for heatmap month (tooltips); optional for older APIs. */
+  completedBookingsPerDayCurrentMonth?: DailyCount[];
+  /** Draft counts for heatmap month (tooltips); optional for older APIs. */
+  draftsPerDayCurrentMonth?: DailyCount[];
   kpi: KpiExtended;
   deliveryTime: DeliveryTimeDistribution;
   exceptionSignalsHeatmap: HeatmapGrid;

--- a/portal/src/lib/dashboard-echarts.test.ts
+++ b/portal/src/lib/dashboard-echarts.test.ts
@@ -95,11 +95,13 @@ describe("buildLast7DaysGroupedBarOption", () => {
     expect(buildLast7DaysGroupedBarOption([], theme, "B", "Avg", "#111", "#222", dow)).toBeNull();
   });
 
-  it("builds two bar series with 30-day benchmark", () => {
-    const daily = Array.from({ length: 10 }, (_, i) => ({
-      date: `2025-01-${String(i + 1).padStart(2, "0")}`,
-      count: i < 5 ? 2 : 4,
-    }));
+  it("builds two bar series with per-weekday averages over the window", () => {
+    const daily: { date: string; count: number }[] = [];
+    for (let d = 1; d <= 14; d++) {
+      const date = `2025-01-${String(d).padStart(2, "0")}`;
+      const count = d === 6 ? 4 : d === 13 ? 8 : 0;
+      daily.push({ date, count });
+    }
     const opt = buildLast7DaysGroupedBarOption(daily, theme, "B", "Avg", "#111", "#222", dow);
     expect(opt).not.toBeNull();
     const series = opt!.series as { type: string; name: string; data: { value: number }[] }[];
@@ -108,9 +110,8 @@ describe("buildLast7DaysGroupedBarOption", () => {
     expect(series[1].type).toBe("bar");
     expect(series[0].data).toHaveLength(7);
     expect(series[1].data).toHaveLength(7);
-    const sum = daily.reduce((s, d) => s + d.count, 0);
-    const bench = Math.max(0, Math.round((sum / daily.length) * 10) / 10);
-    expect(series[1].data.every((d) => d.value === bench)).toBe(true);
+    // last7 ends 2025-01-14 … 2025-01-08; index 5 is Monday 2025-01-13 → avg of Mon = (4+8)/2
+    expect(series[1].data[5].value).toBe(6);
   });
 });
 

--- a/portal/src/lib/dashboard-echarts.ts
+++ b/portal/src/lib/dashboard-echarts.ts
@@ -68,37 +68,53 @@ export function aggregateCouriersForPie(rows: KeyCount[], topN: number, otherLab
   return head;
 }
 
+function averageForUtcWeekday(daily: { date: string; count: number }[], weekdayUtc: number): number {
+  let sum = 0;
+  let n = 0;
+  for (const d of daily) {
+    const dt = new Date(`${d.date}T12:00:00Z`);
+    if (dt.getUTCDay() === weekdayUtc) {
+      sum += d.count;
+      n++;
+    }
+  }
+  if (n === 0) return 0;
+  return Math.round((sum / n) * 10) / 10;
+}
+
 /**
- * Last 7 days: grouped bars — daily bookings vs 30-day average (benchmark), rounded tops.
+ * Last 7 days: grouped bars — actual count per day vs average for that weekday across the window.
  */
 export function buildLast7DaysGroupedBarOption(
   daily: { date: string; count: number }[],
   theme: ThemeSlice,
-  bookingsLabel: string,
-  benchmarkLabel: string,
+  actualLabel: string,
+  weekdayAvgLabel: string,
   primaryBarColor: string,
   benchmarkBarColor: string,
   dowLabelsSunFirst: string[],
 ): EChartsOption | null {
   if (!daily.length) return null;
   const last7 = daily.slice(-7);
-  const sum30 = daily.reduce((s, d) => s + d.count, 0);
-  const avg30 = daily.length ? sum30 / daily.length : 0;
-  const bench = Math.max(0, Math.round(avg30 * 10) / 10);
+  const isoDates = last7.map((d) => d.date);
   const categories = last7.map((d) => {
     const dt = new Date(`${d.date}T12:00:00Z`);
     return dowLabelsSunFirst[dt.getUTCDay()] ?? d.date.slice(5);
   });
   const counts = last7.map((d) => d.count);
-  const benchmark = last7.map(() => bench);
+  const weekdayAverages = last7.map((d) => {
+    const dt = new Date(`${d.date}T12:00:00Z`);
+    return averageForUtcWeekday(daily, dt.getUTCDay());
+  });
   return {
-    grid: { left: 8, right: 8, top: 28, bottom: 8, containLabel: true },
+    grid: { left: 10, right: 10, top: 40, bottom: 28, containLabel: true },
     legend: {
-      bottom: 0,
+      top: 4,
       left: "center",
       textStyle: { color: theme.mutedForeground, fontSize: 11 },
       itemWidth: 12,
       itemHeight: 12,
+      itemGap: 20,
     },
     tooltip: {
       trigger: "axis",
@@ -107,12 +123,28 @@ export function buildLast7DaysGroupedBarOption(
       borderColor: theme.border,
       borderWidth: 1,
       textStyle: { color: theme.foreground },
+      formatter: (params: unknown) => {
+        const items = Array.isArray(params) ? params : [params];
+        const first = items[0] as { dataIndex?: number };
+        const idx = typeof first?.dataIndex === "number" ? first.dataIndex : 0;
+        const date = isoDates[idx] ?? "";
+        const lines = [`<strong>${date}</strong>`];
+        for (const raw of items) {
+          const p = raw as { seriesName?: string; value?: number | number[] };
+          const name = p.seriesName ?? "";
+          const v = Array.isArray(p.value) ? p.value[0] : p.value;
+          if (typeof v !== "number") continue;
+          const display = Number.isInteger(v) ? String(v) : v.toFixed(1);
+          lines.push(`${name}: ${display}`);
+        }
+        return lines.join("<br/>");
+      },
     },
     xAxis: {
       type: "category",
       data: categories,
       axisLine: { lineStyle: { color: theme.border } },
-      axisLabel: { color: theme.mutedForeground, fontSize: 11 },
+      axisLabel: { color: theme.mutedForeground, fontSize: 11, margin: 10 },
     },
     yAxis: {
       type: "value",
@@ -123,23 +155,23 @@ export function buildLast7DaysGroupedBarOption(
     },
     series: [
       {
-        name: bookingsLabel,
+        name: actualLabel,
         type: "bar",
         data: counts.map((value) => ({
           value,
           itemStyle: { color: primaryBarColor, borderRadius: [12, 12, 0, 0] },
         })),
-        barMaxWidth: 22,
-        barGap: "12%",
+        barMaxWidth: 20,
+        barGap: "18%",
       },
       {
-        name: benchmarkLabel,
+        name: weekdayAvgLabel,
         type: "bar",
-        data: benchmark.map((value) => ({
+        data: weekdayAverages.map((value) => ({
           value,
           itemStyle: { color: benchmarkBarColor, borderRadius: [12, 12, 0, 0] },
         })),
-        barMaxWidth: 22,
+        barMaxWidth: 20,
       },
     ],
   };


### PR DESCRIPTION
## Summary
Integrates dashboard UX and API updates for booking stats.

## Changes
- **API:** \completedBookingsPerDayCurrentMonth\ and \draftsPerDayCurrentMonth\ for the selected heatmap month (parallel queries).
- **Portal:** Calendar heatmap cell hover shows completed bookings and draft counts; Recent daily activity compares each day to the **same weekday** average over the last 30 UTC days (not a flat overall average). Legend moved to reduce overlap with axis labels; chart height increased.
- **i18n:** New strings in all locale files.

## Notes
- Target branch: \development\ per repo policy.
- Run full \dotnet test\ after stopping any running API (DLL locks); portal Vitest for \dashboard-echarts\ was green locally.

Made with [Cursor](https://cursor.com)