### PR TITLE
fix(dashboard): no parallel DbContext; drafts scope stats reliability

### DIFF
--- a/CargoHub.Infrastructure/Persistence/BookingRepository.Dashboard.cs
+++ b/CargoHub.Infrastructure/Persistence/BookingRepository.Dashboard.cs
@@ -97,19 +97,17 @@ public sealed partial class BookingRepository
         }
 
         var calendarMonth = BuildBookingsPerDayForMonth(rows, calY, calM);
-        var completedMonthTask = BuildBookingCountsPerCalendarMonthAsync(
+        // Do not run these in parallel: same DbContext instance must not be used concurrently (EF Core).
+        var completedCalendarMonth = await BuildBookingCountsPerCalendarMonthAsync(
             forCustomer.Where(b => !b.IsDraft),
             calY,
             calM,
-            cancellationToken);
-        var draftsMonthTask = BuildBookingCountsPerCalendarMonthAsync(
+            cancellationToken).ConfigureAwait(false);
+        var draftsCalendarMonth = await BuildBookingCountsPerCalendarMonthAsync(
             forCustomer.Where(b => b.IsDraft),
             calY,
             calM,
-            cancellationToken);
-        await Task.WhenAll(completedMonthTask, draftsMonthTask).ConfigureAwait(false);
-        var completedCalendarMonth = await completedMonthTask.ConfigureAwait(false);
-        var draftsCalendarMonth = await draftsMonthTask.ConfigureAwait(false);
+            cancellationToken).ConfigureAwait(false);
         var delivery = await BuildDeliveryTimeDistributionAsync(baseQuery, cancellationToken);
         var exceptionHeat = await BuildExceptionHeatmapAsync(forCustomer, normalizedScope, cancellationToken);
 

--- a/portal/src/app/[locale]/(protected)/dashboard/page.tsx
+++ b/portal/src/app/[locale]/(protected)/dashboard/page.tsx
@@ -307,6 +307,7 @@ export default function DashboardPage() {
     getDashboardStats(token, scope === "all" ? null : scope, heatmapUtc, ac.signal)
       .then((data) => {
         if (id !== statsRequestSeqRef.current) return;
+        setStatsError(null);
         setStats(data);
       })
       .catch((e) => {

--- a/portal/src/lib/api.ts
+++ b/portal/src/lib/api.ts
@@ -1209,6 +1209,8 @@ export async function getDashboardStats(
     headers: { Authorization: `Bearer ${token}` },
     signal,
   });
-  if (!res.ok) throw new Error("Failed to load dashboard stats");
-  return res.json();
+  if (!res.ok) {
+    throw new Error(`Failed to load dashboard stats (HTTP ${res.status})`);
+  }
+  return res.json() as Promise<DashboardStats>;
 }


### PR DESCRIPTION
## Problem
Switching dashboard scope to **Drafts** could trigger \Failed to load dashboard stats\, and the error could appear to stick when toggling back.

## Cause
Two \BuildBookingCountsPerCalendarMonthAsync\ calls were started with \Task.WhenAll\ on the **same scoped \DbContext\**, which EF Core does not allow (concurrent operations).

## Changes
- **Infrastructure:** Run completed-month and draft-month heatmap queries **sequentially**.
- **Portal:** Call \setStatsError(null)\ when a stats response succeeds.
- **api.ts:** Non-OK responses throw with \HTTP {status}\ for easier diagnosis.

## Related
Builds on #190 (in-memory day grouping for Npgsql translation).

Made with [Cursor](https://cursor.com)