### PR TITLE
fix(portal): receiver PartyFields fieldKeyPrefix for Docker/Next build

### DIFF
--- a/portal/src/app/[locale]/(protected)/bookings/create/page.tsx
+++ b/portal/src/app/[locale]/(protected)/bookings/create/page.tsx
@@ -668,7 +668,14 @@ export default function CreateBookingPage() {
                 </select>
               </div>
             )}
-            <PartyFields title="" state={receiver} setState={setReceiver} quickBooking={quickBooking} />
+            <PartyFields
+              title=""
+              state={receiver}
+              setState={setReceiver}
+              quickBooking={quickBooking}
+              fieldKeyPrefix="receiver"
+              fieldErrors={fieldErrors}
+            />
           </CardContent>
         </Card>
 


### PR DESCRIPTION
Fixes TypeScript error on the receiver \PartyFields\ call (missing required \ieldKeyPrefix\ / \ieldErrors\), which broke the Docker all-in-one image at \
pm run build\.

See failed run: Docker validate job on merged PR #196.

Made with [Cursor](https://cursor.com)