### PR TITLE
feat(portal): Actions tabs and toggles for booking field rules

### DIFF
--- a/portal/messages/da.json
+++ b/portal/messages/da.json
@@ -180,6 +180,8 @@
     "title": "Handlinger",
     "description": "Aftalenumre, standardafsender, adressebog og andre firmarelaterede handlinger.",
     "comingSoon": "Kommer snart, når backend-endepunkter er tilgængelige.",
+    "tabAddressBook": "Adressebog",
+    "tabManageBooking": "Administrer booking-side",
     "addressBook": "Adressebog",
     "addressBookDescription": "Afsendere og modtagere per firma. Brug disse, når du opretter bookinger. Deles ikke mellem firmaer.",
     "company": "Firma",

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -319,6 +319,8 @@
     "title": "Actions",
     "description": "Agreement numbers, default shipper, address book and other company-related actions.",
     "comingSoon": "Coming soon when backend endpoints are available.",
+    "tabAddressBook": "Address book",
+    "tabManageBooking": "Manage booking page",
     "addressBook": "Address book",
     "addressBookDescription": "Senders and receivers per company. Use these when creating bookings. Not shared between companies.",
     "company": "Company",

--- a/portal/messages/fi.json
+++ b/portal/messages/fi.json
@@ -274,6 +274,8 @@
     "title": "Toiminnot",
     "description": "Sopimusnumerot, oletuslähettäjä, osoitekirja jne.",
     "comingSoon": "Tulossa, kun taustapalvelut ovat käytettävissä.",
+    "tabAddressBook": "Osoitekirja",
+    "tabManageBooking": "Varauslomakkeen asetukset",
     "addressBook": "Osoitekirja",
     "addressBookDescription": "Lähettäjät ja vastaanottajat yhtiöittäin. Käytä näitä luodessa varauksia. Ei jaettu yhtiöiden välillä.",
     "company": "Yhtiö",

--- a/portal/messages/is.json
+++ b/portal/messages/is.json
@@ -180,6 +180,8 @@
     "title": "Aðgerðir",
     "description": "Samningsnúmer, sjálfgefinn sendandi, vistfangaskrá og aðrar fyrirtækjatengdar aðgerðir.",
     "comingSoon": "Kemur fljótlega þegar backend endapunktar eru tiltækir.",
+    "tabAddressBook": "Vistfangaskrá",
+    "tabManageBooking": "Stjórna bókunarsíðu",
     "addressBook": "Vistfangaskrá",
     "addressBookDescription": "Sendendur og viðtakendur fyrir hvert fyrirtæki. Notaðu þetta þegar þú býrð til bókanir. Ekki deilt milli fyrirtækja.",
     "company": "Fyrirtæki",

--- a/portal/messages/no.json
+++ b/portal/messages/no.json
@@ -180,6 +180,8 @@
     "title": "Handlinger",
     "description": "Avtalenummer, standardavsender, adressebok og andre firmarelaterte handlinger.",
     "comingSoon": "Kommer snart når backend-endepunkter er tilgjengelige.",
+    "tabAddressBook": "Adressebok",
+    "tabManageBooking": "Administrer bookingsside",
     "addressBook": "Adressebok",
     "addressBookDescription": "Avsendere og mottakere per firma. Bruk disse når du oppretter bookinger. Deles ikke mellom firmaer.",
     "company": "Firma",

--- a/portal/messages/sv.json
+++ b/portal/messages/sv.json
@@ -180,6 +180,8 @@
     "title": "Åtgärder",
     "description": "Avtalsnummer, standardavsändare, adressbok och andra företagsrelaterade åtgärder.",
     "comingSoon": "Kommer snart när backend-endpoints är tillgängliga.",
+    "tabAddressBook": "Adressbok",
+    "tabManageBooking": "Hantera bokningssida",
     "addressBook": "Adressbok",
     "addressBookDescription": "Avsändare och mottagare per företag. Använd dessa när du skapar bokningar. Delas inte mellan företag.",
     "company": "Företag",

--- a/portal/src/app/[locale]/(protected)/actions/page.tsx
+++ b/portal/src/app/[locale]/(protected)/actions/page.tsx
@@ -17,6 +17,8 @@ import {
   BOOKING_RULE_SECTION_ORDER,
   type BookingFieldRules,
   type BookingSectionId,
+  type RequirementLevel,
+  applySectionRequirement,
   bookingFieldRulesToApiBody,
   defaultBookingFieldRules,
   defsForSection,
@@ -26,6 +28,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 const emptyEntry: AddressEntry = {
   name: "",
@@ -91,6 +95,10 @@ function sectionDescription(sectionId: BookingSectionId, tSections: (key: string
   }
 }
 
+function isMandatory(level: RequirementLevel | undefined): boolean {
+  return (level ?? "optional") === "mandatory";
+}
+
 export default function ActionsPage() {
   const t = useTranslations("actions");
   const tSections = useTranslations("bookings.sections");
@@ -110,6 +118,7 @@ export default function ActionsPage() {
   const [rulesError, setRulesError] = useState<string | null>(null);
   const [rulesSaving, setRulesSaving] = useState(false);
   const [rulesSavedHint, setRulesSavedHint] = useState(false);
+  const [activeTab, setActiveTab] = useState("addressBook");
 
   const roles = user?.roles ?? [];
   const isSuperAdmin = Array.isArray(roles) && roles.includes("SuperAdmin");
@@ -184,18 +193,19 @@ export default function ActionsPage() {
   }
 
   function isDuplicateEntry(newEntry: AddressEntry, existingList: AddressEntry[]): boolean {
-    return existingList.some((existing) => 
-      (existing.name ?? "").trim().toLowerCase() === (newEntry.name ?? "").trim().toLowerCase() &&
-      (existing.address1 ?? "").trim().toLowerCase() === (newEntry.address1 ?? "").trim().toLowerCase() &&
-      (existing.address2 ?? "").trim().toLowerCase() === (newEntry.address2 ?? "").trim().toLowerCase() &&
-      (existing.postalCode ?? "").trim().toLowerCase() === (newEntry.postalCode ?? "").trim().toLowerCase() &&
-      (existing.city ?? "").trim().toLowerCase() === (newEntry.city ?? "").trim().toLowerCase() &&
-      (existing.country ?? "").trim().toLowerCase() === (newEntry.country ?? "").trim().toLowerCase() &&
-      (existing.email ?? "").trim().toLowerCase() === (newEntry.email ?? "").trim().toLowerCase() &&
-      (existing.phoneNumber ?? "").trim() === (newEntry.phoneNumber ?? "").trim() &&
-      (existing.contactPersonName ?? "").trim().toLowerCase() === (newEntry.contactPersonName ?? "").trim().toLowerCase() &&
-      (existing.vatNo ?? "").trim().toLowerCase() === (newEntry.vatNo ?? "").trim().toLowerCase() &&
-      (existing.customerNumber ?? "").trim().toLowerCase() === (newEntry.customerNumber ?? "").trim().toLowerCase()
+    return existingList.some(
+      (existing) =>
+        (existing.name ?? "").trim().toLowerCase() === (newEntry.name ?? "").trim().toLowerCase() &&
+        (existing.address1 ?? "").trim().toLowerCase() === (newEntry.address1 ?? "").trim().toLowerCase() &&
+        (existing.address2 ?? "").trim().toLowerCase() === (newEntry.address2 ?? "").trim().toLowerCase() &&
+        (existing.postalCode ?? "").trim().toLowerCase() === (newEntry.postalCode ?? "").trim().toLowerCase() &&
+        (existing.city ?? "").trim().toLowerCase() === (newEntry.city ?? "").trim().toLowerCase() &&
+        (existing.country ?? "").trim().toLowerCase() === (newEntry.country ?? "").trim().toLowerCase() &&
+        (existing.email ?? "").trim().toLowerCase() === (newEntry.email ?? "").trim().toLowerCase() &&
+        (existing.phoneNumber ?? "").trim() === (newEntry.phoneNumber ?? "").trim() &&
+        (existing.contactPersonName ?? "").trim().toLowerCase() === (newEntry.contactPersonName ?? "").trim().toLowerCase() &&
+        (existing.vatNo ?? "").trim().toLowerCase() === (newEntry.vatNo ?? "").trim().toLowerCase() &&
+        (existing.customerNumber ?? "").trim().toLowerCase() === (newEntry.customerNumber ?? "").trim().toLowerCase()
     );
   }
 
@@ -243,51 +253,50 @@ export default function ActionsPage() {
 
   if (!isAuthenticated || isLoading) return null;
 
-  return (
-    <div className="space-y-6">
-      <h1 className="text-2xl font-bold tracking-tight">{t("title")}</h1>
-      <Card>
-        <CardHeader>
-          <CardTitle>{t("addressBook")}</CardTitle>
-          <CardDescription>{t("addressBookDescription")}</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {isSuperAdmin && addressBooks.length > 1 && (
-            <div className="space-y-2">
-              <Label className="text-sm">{t("filterByCompany")}</Label>
-              <select
-                className="w-full max-w-md rounded-md border border-input bg-background px-3 py-2 text-sm"
-                value={selectedCompanyId ?? ""}
-                onChange={(e) => setSelectedCompanyId(e.target.value || null)}
-              >
-                {addressBooks.map((ab) => (
-                  <option key={ab.companyId} value={ab.companyId}>
-                    {ab.companyName || ab.companyId}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-          {data?.companyName && (
-            <p className="text-sm text-muted-foreground">
-              {t("company")}: <span className="font-medium">{data.companyName}</span>
-            </p>
-          )}
-          {error && (
-            <p className="text-sm text-destructive" role="alert">
-              {error}
-            </p>
-          )}
-          {loading ? (
-            <p className="text-muted-foreground">{t("loading")}</p>
-          ) : !data ? (
-            <p className="text-muted-foreground">{t("noCompany")}</p>
-          ) : (
-            <div className="space-y-6">
-              {/* Add Forms - hidden for SuperAdmin (view-only address books) */}
-              {!isSuperAdmin && (
+  const companyFilter =
+    isSuperAdmin && addressBooks.length > 1 ? (
+      <div className="space-y-2">
+        <Label className="text-sm">{t("filterByCompany")}</Label>
+        <select
+          className="w-full max-w-md rounded-md border border-input bg-background px-3 py-2 text-sm"
+          value={selectedCompanyId ?? ""}
+          onChange={(e) => setSelectedCompanyId(e.target.value || null)}
+        >
+          {addressBooks.map((ab) => (
+            <option key={ab.companyId} value={ab.companyId}>
+              {ab.companyName || ab.companyId}
+            </option>
+          ))}
+        </select>
+      </div>
+    ) : null;
+
+  const addressBookCard = (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("addressBook")}</CardTitle>
+        <CardDescription>{t("addressBookDescription")}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {!canEditBookingRules ? companyFilter : null}
+        {data?.companyName && (
+          <p className="text-sm text-muted-foreground">
+            {t("company")}: <span className="font-medium">{data.companyName}</span>
+          </p>
+        )}
+        {error && (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+        {loading ? (
+          <p className="text-muted-foreground">{t("loading")}</p>
+        ) : !data ? (
+          <p className="text-muted-foreground">{t("noCompany")}</p>
+        ) : (
+          <div className="space-y-6">
+            {!isSuperAdmin && (
               <div className="grid gap-6 md:grid-cols-2">
-                {/* Add Sender Form */}
                 <form onSubmit={handleAddSender} className="space-y-3 rounded-lg border p-4 bg-muted/20">
                   <h2 className="text-lg font-semibold">{t("addSender")}</h2>
                   <div className="grid gap-2 sm:grid-cols-2">
@@ -352,7 +361,6 @@ export default function ActionsPage() {
                   </Button>
                 </form>
 
-                {/* Add Receiver Form */}
                 <form onSubmit={handleAddReceiver} className="space-y-3 rounded-lg border p-4 bg-muted/20">
                   <h2 className="text-lg font-semibold">{t("addReceiver")}</h2>
                   <div className="grid gap-2 sm:grid-cols-2">
@@ -417,160 +425,197 @@ export default function ActionsPage() {
                   </Button>
                 </form>
               </div>
-              )}
+            )}
 
-              {/* Address Book Lists - Bottom Section */}
-              <div className="grid gap-8 md:grid-cols-2">
-                {/* Senders List */}
-                <div className="space-y-4">
-                  <h2 className="text-lg font-semibold">{t("senders")}</h2>
-                  <table className="w-full text-sm border rounded-md">
-                    <thead>
-                      <tr className="border-b bg-muted/50">
-                        <th className="p-2 text-left font-medium">{t("name")}</th>
-                        <th className="p-2 text-left font-medium">{t("city")}</th>
+            <div className="grid gap-8 md:grid-cols-2">
+              <div className="space-y-4">
+                <h2 className="text-lg font-semibold">{t("senders")}</h2>
+                <table className="w-full text-sm border rounded-md">
+                  <thead>
+                    <tr className="border-b bg-muted/50">
+                      <th className="p-2 text-left font-medium">{t("name")}</th>
+                      <th className="p-2 text-left font-medium">{t("city")}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.senders.length === 0 ? (
+                      <tr>
+                        <td colSpan={2} className="p-3 text-muted-foreground">
+                          {t("noSenders")}
+                        </td>
                       </tr>
-                    </thead>
-                    <tbody>
-                      {data.senders.length === 0 ? (
-                        <tr>
-                          <td colSpan={2} className="p-3 text-muted-foreground">
-                            {t("noSenders")}
-                          </td>
+                    ) : (
+                      data.senders.map((s) => (
+                        <tr key={s.id ?? s.name} className="border-b">
+                          <td className="p-2">{s.name || "—"}</td>
+                          <td className="p-2">{s.city || "—"}</td>
                         </tr>
-                      ) : (
-                        data.senders.map((s) => (
-                          <tr key={s.id ?? s.name} className="border-b">
-                            <td className="p-2">{s.name || "—"}</td>
-                            <td className="p-2">{s.city || "—"}</td>
-                          </tr>
-                        ))
-                      )}
-                    </tbody>
-                  </table>
-                </div>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
 
-                {/* Receivers List */}
-                <div className="space-y-4">
-                  <h2 className="text-lg font-semibold">{t("receivers")}</h2>
-                  <table className="w-full text-sm border rounded-md">
-                    <thead>
-                      <tr className="border-b bg-muted/50">
-                        <th className="p-2 text-left font-medium">{t("name")}</th>
-                        <th className="p-2 text-left font-medium">{t("city")}</th>
+              <div className="space-y-4">
+                <h2 className="text-lg font-semibold">{t("receivers")}</h2>
+                <table className="w-full text-sm border rounded-md">
+                  <thead>
+                    <tr className="border-b bg-muted/50">
+                      <th className="p-2 text-left font-medium">{t("name")}</th>
+                      <th className="p-2 text-left font-medium">{t("city")}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.receivers.length === 0 ? (
+                      <tr>
+                        <td colSpan={2} className="p-3 text-muted-foreground">
+                          {t("noReceivers")}
+                        </td>
                       </tr>
-                    </thead>
-                    <tbody>
-                      {data.receivers.length === 0 ? (
-                        <tr>
-                          <td colSpan={2} className="p-3 text-muted-foreground">
-                            {t("noReceivers")}
-                          </td>
+                    ) : (
+                      data.receivers.map((r) => (
+                        <tr key={r.id ?? r.name} className="border-b">
+                          <td className="p-2">{r.name || "—"}</td>
+                          <td className="p-2">{r.city || "—"}</td>
                         </tr>
-                      ) : (
-                        data.receivers.map((r) => (
-                          <tr key={r.id ?? r.name} className="border-b">
-                            <td className="p-2">{r.name || "—"}</td>
-                            <td className="p-2">{r.city || "—"}</td>
-                          </tr>
-                        ))
-                      )}
-                    </tbody>
-                  </table>
-                </div>
+                      ))
+                    )}
+                  </tbody>
+                </table>
               </div>
             </div>
-          )}
-        </CardContent>
-      </Card>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
 
-      {canEditBookingRules && (
-        <Card>
-          <CardHeader>
-            <CardTitle>{t("bookingFieldRulesTitle")}</CardTitle>
-            <CardDescription>{t("bookingFieldRulesDescription")}</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {isSuperAdmin && !selectedCompanyId ? (
-              <p className="text-sm text-muted-foreground">{t("loading")}</p>
-            ) : rulesLoading ? (
-              <p className="text-sm text-muted-foreground">{t("loading")}</p>
-            ) : (
-              <>
-                {rulesError && (
-                  <p className="text-sm text-destructive" role="alert">
-                    {rulesError}
-                  </p>
-                )}
-                {rulesSavedHint && (
-                  <p className="text-sm text-muted-foreground" role="status">
-                    {t("rulesSaved")}
-                  </p>
-                )}
-                <div className="space-y-6">
-                  {BOOKING_RULE_SECTION_ORDER.map((sectionId) => (
-                    <div key={sectionId} className="rounded-lg border p-4 space-y-3">
-                      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                        <div>
-                          <h3 className="font-semibold text-sm">{sectionTitle(sectionId, tSections, tFields)}</h3>
-                          <p className="text-xs text-muted-foreground">{sectionDescription(sectionId, tSections)}</p>
-                        </div>
-                        <div className="flex items-center gap-2 shrink-0">
-                          <Label className="text-xs whitespace-nowrap">{t("sectionRequirement")}</Label>
-                          <select
-                            className="flex h-9 w-[160px] rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm"
-                            value={rulesDraft.sections[sectionId] ?? "optional"}
-                            onChange={(e) =>
-                              setRulesDraft((prev) => ({
-                                ...prev,
-                                sections: {
-                                  ...prev.sections,
-                                  [sectionId]: e.target.value as "mandatory" | "optional",
-                                },
-                              }))
-                            }
-                          >
-                            <option value="optional">{t("optional")}</option>
-                            <option value="mandatory">{t("mandatory")}</option>
-                          </select>
-                        </div>
+  const manageBookingCard = canEditBookingRules ? (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("bookingFieldRulesTitle")}</CardTitle>
+        <CardDescription>{t("bookingFieldRulesDescription")}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isSuperAdmin && !selectedCompanyId ? (
+          <p className="text-sm text-muted-foreground">{t("loading")}</p>
+        ) : rulesLoading ? (
+          <p className="text-sm text-muted-foreground">{t("loading")}</p>
+        ) : (
+          <>
+            {rulesError && (
+              <p className="text-sm text-destructive" role="alert">
+                {rulesError}
+              </p>
+            )}
+            {rulesSavedHint && (
+              <p className="text-sm text-muted-foreground" role="status">
+                {t("rulesSaved")}
+              </p>
+            )}
+            <div className="space-y-6">
+              {BOOKING_RULE_SECTION_ORDER.map((sectionId) => {
+                const sectionMandatory = isMandatory(rulesDraft.sections[sectionId]);
+                return (
+                  <div key={sectionId} className="rounded-lg border p-4 space-y-3">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div>
+                        <h3 className="font-semibold text-sm">{sectionTitle(sectionId, tSections, tFields)}</h3>
+                        <p className="text-xs text-muted-foreground">{sectionDescription(sectionId, tSections)}</p>
                       </div>
-                      <div className="space-y-2 pl-0 sm:pl-1">
-                        {defsForSection(sectionId).map((def) => (
+                      <div className="flex items-center gap-3 shrink-0">
+                        <Label htmlFor={`section-${sectionId}`} className="text-xs whitespace-nowrap cursor-pointer">
+                          {t("sectionRequirement")}
+                        </Label>
+                        <Switch
+                          id={`section-${sectionId}`}
+                          checked={sectionMandatory}
+                          onCheckedChange={(checked) =>
+                            setRulesDraft((prev) =>
+                              applySectionRequirement(prev, sectionId, checked ? "mandatory" : "optional")
+                            )
+                          }
+                          aria-label={t("sectionRequirement")}
+                        />
+                        <span className="text-xs text-muted-foreground w-20">
+                          {sectionMandatory ? t("mandatory") : t("optional")}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="space-y-2 pl-0 sm:pl-1">
+                      {defsForSection(sectionId).map((def) => {
+                        const fieldMandatory = isMandatory(rulesDraft.fields[def.fieldId]);
+                        const lockedBySection = sectionMandatory;
+                        const showChecked = lockedBySection || fieldMandatory;
+                        return (
                           <div
                             key={def.fieldId}
                             className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between border-t border-border/60 pt-2 first:border-t-0 first:pt-0"
                           >
-                            <Label className="text-sm font-normal">{tFields(def.labelKey as "name")}</Label>
-                            <select
-                              className="flex h-9 w-[160px] rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm sm:shrink-0"
-                              value={rulesDraft.fields[def.fieldId] ?? "optional"}
-                              onChange={(e) =>
-                                setRulesDraft((prev) => ({
-                                  ...prev,
-                                  fields: {
-                                    ...prev.fields,
-                                    [def.fieldId]: e.target.value as "mandatory" | "optional",
-                                  },
-                                }))
-                              }
+                            <Label
+                              htmlFor={`field-${def.fieldId}`}
+                              className="text-sm font-normal cursor-pointer sm:max-w-[55%]"
                             >
-                              <option value="optional">{t("optional")}</option>
-                              <option value="mandatory">{t("mandatory")}</option>
-                            </select>
+                              {tFields(def.labelKey as "name")}
+                            </Label>
+                            <div className="flex items-center gap-3 sm:shrink-0">
+                              <Switch
+                                id={`field-${def.fieldId}`}
+                                checked={showChecked}
+                                disabled={lockedBySection}
+                                onCheckedChange={(checked) => {
+                                  if (lockedBySection) return;
+                                  setRulesDraft((prev) => ({
+                                    ...prev,
+                                    fields: {
+                                      ...prev.fields,
+                                      [def.fieldId]: checked ? "mandatory" : "optional",
+                                    },
+                                  }));
+                                }}
+                                aria-label={tFields(def.labelKey as "name")}
+                              />
+                              <span className="text-xs text-muted-foreground w-20">
+                                {showChecked ? t("mandatory") : t("optional")}
+                              </span>
+                            </div>
                           </div>
-                        ))}
-                      </div>
+                        );
+                      })}
                     </div>
-                  ))}
-                </div>
-                <Button type="button" onClick={() => void handleSaveBookingRules()} disabled={rulesSaving}>
-                  {rulesSaving ? t("savingRules") : t("saveRules")}
-                </Button>
-              </>
-            )}
-          </CardContent>
-        </Card>
+                  </div>
+                );
+              })}
+            </div>
+            <Button type="button" onClick={() => void handleSaveBookingRules()} disabled={rulesSaving}>
+              {rulesSaving ? t("savingRules") : t("saveRules")}
+            </Button>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  ) : null;
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold tracking-tight">{t("title")}</h1>
+
+      {canEditBookingRules ? (
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+          {companyFilter ? <div className="mb-2">{companyFilter}</div> : null}
+          <TabsList>
+            <TabsTrigger value="addressBook">{t("tabAddressBook")}</TabsTrigger>
+            <TabsTrigger value="manageBooking">{t("tabManageBooking")}</TabsTrigger>
+          </TabsList>
+          <TabsContent value="addressBook" className="mt-4">
+            {addressBookCard}
+          </TabsContent>
+          <TabsContent value="manageBooking" className="mt-4">
+            {manageBookingCard}
+          </TabsContent>
+        </Tabs>
+      ) : (
+        addressBookCard
       )}
     </div>
   );

--- a/portal/src/components/ui/switch.tsx
+++ b/portal/src/components/ui/switch.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as React from "react";
+import { Switch as SwitchParts } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Switch({ className, ...props }: React.ComponentProps<typeof SwitchParts.Root>) {
+  return (
+    <SwitchParts.Root
+      data-slot="switch"
+      className={cn(
+        "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent shadow-sm transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+        className
+      )}
+      {...props}
+    >
+      <SwitchParts.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block size-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchParts.Root>
+  );
+}
+
+export { Switch };

--- a/portal/src/components/ui/tabs.tsx
+++ b/portal/src/components/ui/tabs.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+import { Tabs as TabsPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Tabs({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return <TabsPrimitive.Root data-slot="tabs" className={cn("flex flex-col gap-4", className)} {...props} />;
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "inline-flex h-9 w-fit items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2", className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsContent, TabsList, TabsTrigger };

--- a/portal/src/lib/booking-field-rules.test.ts
+++ b/portal/src/lib/booking-field-rules.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applySectionRequirement,
   bookingFieldRulesToApiBody,
   defaultBookingFieldRules,
   isFieldRequired,
@@ -51,6 +52,16 @@ describe("parseBookingFieldRulesFromApi", () => {
     expect(r.sections.shipper).toBe("mandatory");
     expect(r.fields["shipper.name"]).toBe("optional");
   });
+
+  it("strips legacy courier field rules from stored payload", () => {
+    const r = parseBookingFieldRulesFromApi({
+      version: 1,
+      sections: { shipper: "optional" },
+      fields: { "courier.postalService": "mandatory", "shipper.name": "optional" },
+    });
+    expect(r.fields["courier.postalService"]).toBeUndefined();
+    expect(r.fields["shipper.name"]).toBe("optional");
+  });
 });
 
 describe("isFieldRequired", () => {
@@ -96,14 +107,6 @@ describe("validateBookingCreateForm", () => {
     packages: [pkg({ weight: "1", packageType: "box" })],
   });
 
-  it("flags empty postal service when courier mandatory", () => {
-    const rules = defaultBookingFieldRules();
-    rules.sections.courier = "mandatory";
-    const ctx = { ...baseCtx(), postalService: "" };
-    const err = validateBookingCreateForm(ctx, rules, "Required");
-    expect(err["courier.postalService"]).toBe("Required");
-  });
-
   it("skips payer party when payer is sender", () => {
     const rules = defaultBookingFieldRules();
     rules.sections.payer = "mandatory";
@@ -135,5 +138,25 @@ describe("bookingFieldRulesToApiBody", () => {
     expect(body.version).toBe(1);
     expect(body.sections.shipper).toBe("optional");
     expect(body.fields["shipper.name"]).toBe("optional");
+    expect(body.sections.courier).toBeUndefined();
+    expect(body.fields["courier.postalService"]).toBeUndefined();
+  });
+});
+
+describe("applySectionRequirement", () => {
+  it("sets all fields in section to mandatory when section is mandatory", () => {
+    let rules = defaultBookingFieldRules();
+    rules = applySectionRequirement(rules, "shipper", "mandatory");
+    expect(rules.sections.shipper).toBe("mandatory");
+    expect(rules.fields["shipper.name"]).toBe("mandatory");
+    expect(rules.fields["shipper.email"]).toBe("mandatory");
+  });
+
+  it("does not clear field entries when section becomes optional", () => {
+    let rules = defaultBookingFieldRules();
+    rules = applySectionRequirement(rules, "receiver", "mandatory");
+    rules = applySectionRequirement(rules, "receiver", "optional");
+    expect(rules.sections.receiver).toBe("optional");
+    expect(rules.fields["receiver.name"]).toBe("mandatory");
   });
 });

--- a/portal/src/lib/booking-field-rules.ts
+++ b/portal/src/lib/booking-field-rules.ts
@@ -70,9 +70,8 @@ function partyLabelKey(k: PartyFieldKey): string {
   return map[k];
 }
 
-/** All configurable fields in booking create form order (mirrors UI sections). */
+/** All configurable fields in booking create form order (mirrors UI sections). Courier is not configurable here. */
 export const BOOKING_RULE_FIELD_DEFINITIONS: BookingRuleFieldDef[] = [
-  { sectionId: "courier", fieldId: "courier.postalService", labelKey: "postalService" },
   ...partyDefs("shipper", "shipper"),
   ...partyDefs("receiver", "receiver"),
   ...partyDefs("payer", "payer"),
@@ -110,8 +109,8 @@ export const BOOKING_RULE_FIELD_DEFINITIONS: BookingRuleFieldDef[] = [
   { sectionId: "packages", fieldId: "package.height", labelKey: "height" },
 ];
 
+/** Sections shown in Actions → Manage booking (postal/courier is not included). */
 export const BOOKING_RULE_SECTION_ORDER: BookingSectionId[] = [
-  "courier",
   "shipper",
   "receiver",
   "payer",
@@ -152,6 +151,8 @@ export function parseBookingFieldRulesFromApi(data: unknown): BookingFieldRules 
       if (k.trim()) fields[k.trim()] = normLevel(v != null ? String(v) : undefined);
     }
   }
+  delete sections.courier;
+  delete fields["courier.postalService"];
   return { version, sections, fields };
 }
 
@@ -221,10 +222,6 @@ export function validateBookingCreateForm(
 
   const req = (sectionId: BookingSectionId, fieldId: string) =>
     isFieldRequired(sectionId, fieldId, rules);
-
-  if (req("courier", "courier.postalService") && isEmpty(ctx.postalService)) {
-    errors["courier.postalService"] = requiredMessage;
-  }
 
   const checkParty = (sectionId: BookingSectionId, prefix: string, party: CreateBookingParty) => {
     for (const key of partyKeysVisible(ctx.quickBooking)) {
@@ -314,4 +311,20 @@ export function validateBookingCreateForm(
 
 export function defsForSection(sectionId: BookingSectionId): BookingRuleFieldDef[] {
   return BOOKING_RULE_FIELD_DEFINITIONS.filter((d) => d.sectionId === sectionId);
+}
+
+/** When a whole section is set to mandatory, every field in that section is set to mandatory in draft state. */
+export function applySectionRequirement(
+  prev: BookingFieldRules,
+  sectionId: BookingSectionId,
+  level: RequirementLevel
+): BookingFieldRules {
+  const sections = { ...prev.sections, [sectionId]: level };
+  const fields = { ...prev.fields };
+  if (level === "mandatory") {
+    for (const def of defsForSection(sectionId)) {
+      fields[def.fieldId] = "mandatory";
+    }
+  }
+  return { ...prev, sections, fields };
 }


### PR DESCRIPTION
Adds **Address book** and **Manage booking page** tabs under Actions for admins. Booking form requirements use **switches** instead of dropdowns, drop courier from configurable rules, and when a **whole section** is mandatory all fields in that section are set mandatory with field toggles disabled until the section is optional again. Includes \switch\ and \	abs\ UI components and i18n updates.

Made with [Cursor](https://cursor.com)