### PR TITLE
feat(portal): draft save without validation; confirm + create footer UX

### DIFF
--- a/portal/messages/da.json
+++ b/portal/messages/da.json
@@ -174,7 +174,9 @@
     "noCouriersBannerTitle": "Courier setup required",
     "noCouriersBannerAdmin": "Your company has no courier contracts yet. Add the carriers you use and your contract IDs before creating bookings.",
     "noCouriersBannerUser": "Your company has not configured courier contracts yet. Ask a company administrator to set them up.",
-    "goToCourierContracts": "Open courier contracts"
+    "goToCourierContracts": "Open courier contracts",
+    "fieldRequired": "Dette felt er påkrævet.",
+    "validationActionBanner": "Nogle påkrævede felter mangler. Rul op til de fremhævede fejl og prøv igen."
   },
   "actions": {
     "title": "Handlinger",

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -183,6 +183,7 @@
     "quickBooking": "Quick booking",
     "quickBookingDescription": "When enabled, only mandatory fields in each section are shown; optional fields are hidden.",
     "fieldRequired": "This field is required.",
+    "validationActionBanner": "Some required fields are missing. Scroll up to the highlighted errors, fix them, then try again.",
     "optional": "Optional",
     "sections": {
       "header": "Header",

--- a/portal/messages/fi.json
+++ b/portal/messages/fi.json
@@ -182,6 +182,7 @@
     "quickBooking": "Pikavaraus",
     "quickBookingDescription": "Kun käytössä, näytetään vain pakolliset kentät jokaisessa osiossa; valinnaiset kentät piilotetaan.",
     "fieldRequired": "Tämä kenttä on pakollinen.",
+    "validationActionBanner": "Joitakin pakollisia kenttiä puuttuu. Tarkista yläpuolella korostetut virheet ja yritä uudelleen.",
     "optional": "Valinnainen",
     "sections": {
       "header": "Otsikko",

--- a/portal/messages/is.json
+++ b/portal/messages/is.json
@@ -174,7 +174,9 @@
     "noCouriersBannerTitle": "Courier setup required",
     "noCouriersBannerAdmin": "Your company has no courier contracts yet. Add the carriers you use and your contract IDs before creating bookings.",
     "noCouriersBannerUser": "Your company has not configured courier contracts yet. Ask a company administrator to set them up.",
-    "goToCourierContracts": "Open courier contracts"
+    "goToCourierContracts": "Open courier contracts",
+    "fieldRequired": "Þetta reit er skylda.",
+    "validationActionBanner": "Sum skyldureitir vantar. Skrunaðu upp að merktum villum og reyndu aftur."
   },
   "actions": {
     "title": "Aðgerðir",

--- a/portal/messages/no.json
+++ b/portal/messages/no.json
@@ -174,7 +174,9 @@
     "noCouriersBannerTitle": "Courier setup required",
     "noCouriersBannerAdmin": "Your company has no courier contracts yet. Add the carriers you use and your contract IDs before creating bookings.",
     "noCouriersBannerUser": "Your company has not configured courier contracts yet. Ask a company administrator to set them up.",
-    "goToCourierContracts": "Open courier contracts"
+    "goToCourierContracts": "Open courier contracts",
+    "fieldRequired": "Dette feltet er obligatorisk.",
+    "validationActionBanner": "Noen obligatoriske felt mangler. Bla opp til de markerte feilene og prøv igjen."
   },
   "actions": {
     "title": "Handlinger",

--- a/portal/messages/sv.json
+++ b/portal/messages/sv.json
@@ -174,7 +174,9 @@
     "noCouriersBannerTitle": "Courier setup required",
     "noCouriersBannerAdmin": "Your company has no courier contracts yet. Add the carriers you use and your contract IDs before creating bookings.",
     "noCouriersBannerUser": "Your company has not configured courier contracts yet. Ask a company administrator to set them up.",
-    "goToCourierContracts": "Open courier contracts"
+    "goToCourierContracts": "Open courier contracts",
+    "fieldRequired": "Det här fältet är obligatoriskt.",
+    "validationActionBanner": "Obligatoriska fält saknas. Bläddra upp till markerade fel och försök igen."
   },
   "actions": {
     "title": "Åtgärder",

--- a/portal/src/app/[locale]/(protected)/bookings/create/page.tsx
+++ b/portal/src/app/[locale]/(protected)/bookings/create/page.tsx
@@ -459,6 +459,12 @@ export default function CreateBookingPage() {
     if (Object.keys(validationErrors).length > 0) {
       setFieldErrors(validationErrors);
       setError(null);
+      setTimeout(() =>
+        document.getElementById("create-booking-validation-banner")?.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        })
+      );
       return;
     }
     setFieldErrors({});
@@ -491,12 +497,6 @@ export default function CreateBookingPage() {
     if (!token) return;
     if (couriersReady && courierIds.length === 0) {
       setError(t("noCouriersBannerTitle"));
-      return;
-    }
-    const validationErrors = runBookingValidation();
-    if (Object.keys(validationErrors).length > 0) {
-      setFieldErrors(validationErrors);
-      setError(null);
       return;
     }
     setFieldErrors({});
@@ -1070,8 +1070,8 @@ export default function CreateBookingPage() {
           </CardContent>
         </Card>
 
-        <div className="flex gap-2">
-          <label className="flex items-center gap-2 text-sm">
+        <div className="space-y-3 border-t pt-4">
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
             <input
               type="checkbox"
               checked={saveToAddressBook}
@@ -1080,25 +1080,33 @@ export default function CreateBookingPage() {
             />
             <span>{t("saveToAddressBook")}</span>
           </label>
-          <Button
-            type="submit"
-            disabled={submitting || (couriersReady && courierIds.length === 0)}
-          >
-            {submitting ? t("creating") : t("createTitle")}
-          </Button>
-          <Button
-            type="button"
-            variant="secondary"
-            disabled={submitting || (couriersReady && courierIds.length === 0)}
-            onClick={handleSaveDraft}
-          >
-            {submitting ? t("saving") : t("saveAsDraft")}
-          </Button>
-          <Link href="/bookings">
-            <Button type="button" variant="outline">
-              {t("cancel")}
+          <div className="flex flex-wrap items-center gap-3">
+            {Object.keys(fieldErrors).length > 0 ? (
+              <p className="text-sm text-destructive shrink-0 max-w-md" role="alert" id="create-booking-validation-banner">
+                {t("validationActionBanner")}
+              </p>
+            ) : null}
+            <Button
+              type="submit"
+              disabled={submitting || (couriersReady && courierIds.length === 0)}
+              aria-describedby={Object.keys(fieldErrors).length > 0 ? "create-booking-validation-banner" : undefined}
+            >
+              {submitting ? t("creating") : t("createTitle")}
             </Button>
-          </Link>
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={submitting || (couriersReady && courierIds.length === 0)}
+              onClick={handleSaveDraft}
+            >
+              {submitting ? t("saving") : t("saveAsDraft")}
+            </Button>
+            <Link href="/bookings">
+              <Button type="button" variant="outline">
+                {t("cancel")}
+              </Button>
+            </Link>
+          </div>
         </div>
       </form>
     </div>

--- a/portal/src/app/[locale]/(protected)/bookings/draft/[id]/page.tsx
+++ b/portal/src/app/[locale]/(protected)/bookings/draft/[id]/page.tsx
@@ -4,18 +4,76 @@ import { useAuth } from "@/context/AuthContext";
 import { Link } from "@/i18n/navigation";
 import { useRouter } from "@/i18n/navigation";
 import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
-import { draftGet, draftUpdate, draftConfirm, type BookingDetail, type UpdateDraftBody } from "@/lib/api";
+import { useTranslations } from "next-intl";
+import { useEffect, useState, useCallback } from "react";
+import {
+  draftGet,
+  draftUpdate,
+  draftConfirm,
+  getBookingFieldRules,
+  type BookingDetail,
+  type BookingDetailParty,
+  type UpdateDraftBody,
+} from "@/lib/api";
+import {
+  defaultBookingFieldRules,
+  parseBookingFieldRulesFromApi,
+  validateBookingCreateForm,
+  validationContextFromBookingDetail,
+  type BookingFieldRules,
+} from "@/lib/booking-field-rules";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+
+const emptyParty = (): BookingDetailParty => ({
+  name: "",
+  address1: "",
+  postalCode: "",
+  city: "",
+  country: "FI",
+});
+
+function mergeReceiverFormIntoDraft(
+  base: BookingDetail,
+  form: {
+    referenceNumber: string;
+    receiverName: string;
+    receiverAddress1: string;
+    receiverPostalCode: string;
+    receiverCity: string;
+    receiverCountry: string;
+    receiverEmail: string;
+    receiverPhone: string;
+  }
+): BookingDetail {
+  const prev = base.receiver ?? emptyParty();
+  return {
+    ...base,
+    header: {
+      ...base.header,
+      referenceNumber: form.referenceNumber.trim() || base.header?.referenceNumber || null,
+    },
+    receiver: {
+      ...prev,
+      name: form.receiverName.trim(),
+      address1: form.receiverAddress1.trim(),
+      postalCode: form.receiverPostalCode.trim(),
+      city: form.receiverCity.trim(),
+      country: form.receiverCountry.trim() || "FI",
+      email: form.receiverEmail.trim() || null,
+      phoneNumber: form.receiverPhone.trim() || null,
+    },
+  };
+}
 
 export default function DraftDetailPage() {
   const params = useParams();
   const id = params?.id as string;
   const { token, user, isAuthenticated, isLoading } = useAuth();
   const router = useRouter();
+  const t = useTranslations("bookings");
   const isSuperAdmin = Array.isArray(user?.roles) && user.roles.includes("SuperAdmin");
   const [draft, setDraft] = useState<BookingDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -30,6 +88,10 @@ export default function DraftDetailPage() {
   const [receiverPhone, setReceiverPhone] = useState("");
   const [saving, setSaving] = useState(false);
   const [confirming, setConfirming] = useState(false);
+  const [bookingRules, setBookingRules] = useState<BookingFieldRules>(() => defaultBookingFieldRules());
+  const [confirmFieldErrors, setConfirmFieldErrors] = useState<Record<string, string>>({});
+
+  const clearConfirmFieldErrors = useCallback(() => setConfirmFieldErrors({}), []);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -55,9 +117,17 @@ export default function DraftDetailPage() {
       .finally(() => setLoading(false));
   }, [token, id, isAuthenticated, isLoading, router]);
 
+  useEffect(() => {
+    if (!token || isSuperAdmin) return;
+    getBookingFieldRules(token)
+      .then((api) => setBookingRules(parseBookingFieldRulesFromApi(api)))
+      .catch(() => setBookingRules(defaultBookingFieldRules()));
+  }, [token, isSuperAdmin]);
+
   async function handleSave() {
     if (!token || !id) return;
     setError(null);
+    clearConfirmFieldErrors();
     setSaving(true);
     const body: UpdateDraftBody = {
       referenceNumber: referenceNumber.trim() || undefined,
@@ -80,8 +150,31 @@ export default function DraftDetailPage() {
   }
 
   async function handleConfirm() {
-    if (!token || !id) return;
+    if (!token || !id || !draft) return;
     setError(null);
+    const merged = mergeReceiverFormIntoDraft(draft, {
+      referenceNumber,
+      receiverName,
+      receiverAddress1,
+      receiverPostalCode,
+      receiverCity,
+      receiverCountry,
+      receiverEmail,
+      receiverPhone,
+    });
+    const ctx = validationContextFromBookingDetail(merged, false);
+    const validationErrors = validateBookingCreateForm(ctx, bookingRules, t("fieldRequired"));
+    if (Object.keys(validationErrors).length > 0) {
+      setConfirmFieldErrors(validationErrors);
+      setTimeout(() =>
+        document.getElementById("draft-confirm-validation-banner")?.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        })
+      );
+      return;
+    }
+    setConfirmFieldErrors({});
     setConfirming(true);
     try {
       const completed = await draftConfirm(token, id);
@@ -93,6 +186,8 @@ export default function DraftDetailPage() {
     }
   }
 
+  const receiverErr = (suffix: string) => confirmFieldErrors[`receiver.${suffix}`];
+
   if (!isAuthenticated || isLoading) return null;
 
   return (
@@ -101,9 +196,7 @@ export default function DraftDetailPage() {
         <Link href="/bookings">
           <Button variant="ghost">Back</Button>
         </Link>
-        <h1 className="text-2xl font-bold tracking-tight">
-          Draft {id?.slice(0, 8)}
-        </h1>
+        <h1 className="text-2xl font-bold tracking-tight">Draft {id?.slice(0, 8)}</h1>
       </div>
       {error && (
         <p className="text-sm text-destructive" role="alert">
@@ -120,7 +213,7 @@ export default function DraftDetailPage() {
               <CardDescription>
                 {isSuperAdmin
                   ? "View-only. You cannot edit or confirm this draft."
-                  : "Fill in the rest and save. When ready, confirm to complete the booking."}
+                  : "Fill in the rest and save. When ready, confirm to complete the booking. Required fields are checked only when you confirm."}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -130,7 +223,10 @@ export default function DraftDetailPage() {
                   <Input
                     id="reference"
                     value={referenceNumber}
-                    onChange={(e) => setReferenceNumber(e.target.value)}
+                    onChange={(e) => {
+                      setReferenceNumber(e.target.value);
+                      clearConfirmFieldErrors();
+                    }}
                     placeholder="Optional"
                     readOnly={isSuperAdmin}
                     className={isSuperAdmin ? "bg-muted" : undefined}
@@ -145,55 +241,95 @@ export default function DraftDetailPage() {
                     <Input
                       id="receiverName"
                       value={receiverName}
-                      onChange={(e) => setReceiverName(e.target.value)}
+                      onChange={(e) => {
+                        setReceiverName(e.target.value);
+                        clearConfirmFieldErrors();
+                      }}
                       placeholder="Receiver name"
                       readOnly={isSuperAdmin}
                       className={isSuperAdmin ? "bg-muted" : undefined}
                     />
+                    {receiverErr("name") ? (
+                      <p className="text-xs text-destructive" role="alert">
+                        {receiverErr("name")}
+                      </p>
+                    ) : null}
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="receiverAddress1">Address</Label>
                     <Input
                       id="receiverAddress1"
                       value={receiverAddress1}
-                      onChange={(e) => setReceiverAddress1(e.target.value)}
+                      onChange={(e) => {
+                        setReceiverAddress1(e.target.value);
+                        clearConfirmFieldErrors();
+                      }}
                       placeholder="Street address"
                       readOnly={isSuperAdmin}
                       className={isSuperAdmin ? "bg-muted" : undefined}
                     />
+                    {receiverErr("address1") ? (
+                      <p className="text-xs text-destructive" role="alert">
+                        {receiverErr("address1")}
+                      </p>
+                    ) : null}
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="receiverPostalCode">Postal code</Label>
                     <Input
                       id="receiverPostalCode"
                       value={receiverPostalCode}
-                      onChange={(e) => setReceiverPostalCode(e.target.value)}
+                      onChange={(e) => {
+                        setReceiverPostalCode(e.target.value);
+                        clearConfirmFieldErrors();
+                      }}
                       placeholder="00100"
                       readOnly={isSuperAdmin}
                       className={isSuperAdmin ? "bg-muted" : undefined}
                     />
+                    {receiverErr("postalCode") ? (
+                      <p className="text-xs text-destructive" role="alert">
+                        {receiverErr("postalCode")}
+                      </p>
+                    ) : null}
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="receiverCity">City</Label>
                     <Input
                       id="receiverCity"
                       value={receiverCity}
-                      onChange={(e) => setReceiverCity(e.target.value)}
+                      onChange={(e) => {
+                        setReceiverCity(e.target.value);
+                        clearConfirmFieldErrors();
+                      }}
                       placeholder="Helsinki"
                       readOnly={isSuperAdmin}
                       className={isSuperAdmin ? "bg-muted" : undefined}
                     />
+                    {receiverErr("city") ? (
+                      <p className="text-xs text-destructive" role="alert">
+                        {receiverErr("city")}
+                      </p>
+                    ) : null}
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="receiverCountry">Country</Label>
                     <Input
                       id="receiverCountry"
                       value={receiverCountry}
-                      onChange={(e) => setReceiverCountry(e.target.value)}
+                      onChange={(e) => {
+                        setReceiverCountry(e.target.value);
+                        clearConfirmFieldErrors();
+                      }}
                       placeholder="FI"
                       readOnly={isSuperAdmin}
                       className={isSuperAdmin ? "bg-muted" : undefined}
                     />
+                    {receiverErr("country") ? (
+                      <p className="text-xs text-destructive" role="alert">
+                        {receiverErr("country")}
+                      </p>
+                    ) : null}
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="receiverEmail">Email</Label>
@@ -201,37 +337,75 @@ export default function DraftDetailPage() {
                       id="receiverEmail"
                       type="email"
                       value={receiverEmail}
-                      onChange={(e) => setReceiverEmail(e.target.value)}
+                      onChange={(e) => {
+                        setReceiverEmail(e.target.value);
+                        clearConfirmFieldErrors();
+                      }}
                       placeholder="Optional"
                       readOnly={isSuperAdmin}
                       className={isSuperAdmin ? "bg-muted" : undefined}
                     />
+                    {receiverErr("email") ? (
+                      <p className="text-xs text-destructive" role="alert">
+                        {receiverErr("email")}
+                      </p>
+                    ) : null}
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="receiverPhone">Phone</Label>
                     <Input
                       id="receiverPhone"
                       value={receiverPhone}
-                      onChange={(e) => setReceiverPhone(e.target.value)}
+                      onChange={(e) => {
+                        setReceiverPhone(e.target.value);
+                        clearConfirmFieldErrors();
+                      }}
                       placeholder="Optional"
                       readOnly={isSuperAdmin}
                       className={isSuperAdmin ? "bg-muted" : undefined}
                     />
+                    {receiverErr("phoneNumber") ? (
+                      <p className="text-xs text-destructive" role="alert">
+                        {receiverErr("phoneNumber")}
+                      </p>
+                    ) : null}
                   </div>
                 </div>
               </div>
               {!isSuperAdmin && (
-              <div className="flex gap-2 pt-2">
-                <Button type="button" onClick={handleSave} disabled={saving}>
-                  {saving ? "Saving…" : "Save draft"}
-                </Button>
-                <Button type="button" onClick={handleConfirm} disabled={confirming}>
-                  {confirming ? "Confirming…" : "Confirm & complete booking"}
-                </Button>
-                <Link href="/bookings">
-                  <Button type="button" variant="outline">Cancel</Button>
-                </Link>
-              </div>
+                <div className="space-y-3 border-t pt-4">
+                  {Object.keys(confirmFieldErrors).length > 0 ? (
+                    <p
+                      className="text-sm text-destructive"
+                      role="alert"
+                      id="draft-confirm-validation-banner"
+                    >
+                      {t("validationActionBanner")}
+                    </p>
+                  ) : null}
+                  <div className="flex flex-wrap gap-2">
+                    <Button type="button" onClick={handleSave} disabled={saving}>
+                      {saving ? "Saving…" : "Save draft"}
+                    </Button>
+                    <Button
+                      type="button"
+                      onClick={() => void handleConfirm()}
+                      disabled={confirming}
+                      aria-describedby={
+                        Object.keys(confirmFieldErrors).length > 0
+                          ? "draft-confirm-validation-banner"
+                          : undefined
+                      }
+                    >
+                      {confirming ? "Confirming…" : "Confirm & complete booking"}
+                    </Button>
+                    <Link href="/bookings">
+                      <Button type="button" variant="outline">
+                        Cancel
+                      </Button>
+                    </Link>
+                  </div>
+                </div>
               )}
               {isSuperAdmin && (
                 <div className="pt-2">

--- a/portal/src/lib/booking-field-rules.test.ts
+++ b/portal/src/lib/booking-field-rules.test.ts
@@ -3,11 +3,13 @@ import {
   applySectionRequirement,
   bookingFieldRulesToApiBody,
   defaultBookingFieldRules,
+  inferPayerSourceFromBookingDetail,
   isFieldRequired,
   parseBookingFieldRulesFromApi,
   validateBookingCreateForm,
+  validationContextFromBookingDetail,
 } from "./booking-field-rules";
-import type { CreateBookingPackage, CreateBookingParty } from "./api";
+import type { BookingDetail, CreateBookingPackage, CreateBookingParty } from "./api";
 
 const party = (over: Partial<CreateBookingParty> = {}): CreateBookingParty => ({
   name: "",
@@ -140,6 +142,47 @@ describe("bookingFieldRulesToApiBody", () => {
     expect(body.fields["shipper.name"]).toBe("optional");
     expect(body.sections.courier).toBeUndefined();
     expect(body.fields["courier.postalService"]).toBeUndefined();
+  });
+});
+
+describe("validationContextFromBookingDetail", () => {
+  const minimalDetail = (): BookingDetail => ({
+    id: "d1",
+    customerId: "c1",
+    enabled: false,
+    isTestBooking: false,
+    isFavourite: false,
+    isDraft: true,
+    createdAtUtc: "",
+    updatedAtUtc: "",
+    header: { senderId: "s1", postalService: "Posti" },
+    shipper: {
+      name: "S",
+      address1: "A",
+      postalCode: "1",
+      city: "C",
+      country: "FI",
+    },
+    receiver: {
+      name: "R",
+      address1: "B",
+      postalCode: "2",
+      city: "D",
+      country: "FI",
+    },
+  });
+
+  it("maps parties and infers payer sender when payer empty", () => {
+    const ctx = validationContextFromBookingDetail(minimalDetail(), false);
+    expect(ctx.postalService).toBe("Posti");
+    expect(ctx.payerSource).toBe("sender");
+    expect(ctx.shipper.name).toBe("S");
+  });
+
+  it("infers payer receiver when payer matches receiver", () => {
+    const d = minimalDetail();
+    d.payer = { ...d.receiver! };
+    expect(inferPayerSourceFromBookingDetail(d)).toBe("receiver");
   });
 });
 

--- a/portal/src/lib/booking-field-rules.ts
+++ b/portal/src/lib/booking-field-rules.ts
@@ -1,4 +1,10 @@
-import type { BookingFieldRulesApi, CreateBookingPackage, CreateBookingParty } from "@/lib/api";
+import type {
+  BookingDetail,
+  BookingDetailParty,
+  BookingFieldRulesApi,
+  CreateBookingPackage,
+  CreateBookingParty,
+} from "@/lib/api";
 
 export type BookingSectionId =
   | "courier"
@@ -327,4 +333,130 @@ export function applySectionRequirement(
     }
   }
   return { ...prev, sections, fields };
+}
+
+const emptyParty = (): CreateBookingParty => ({
+  name: "",
+  address1: "",
+  address2: "",
+  postalCode: "",
+  city: "",
+  country: "FI",
+  email: "",
+  phoneNumber: "",
+  phoneNumberMobile: "",
+  contactPersonName: "",
+  vatNo: "",
+  customerNumber: "",
+});
+
+function detailPartyToParty(p?: BookingDetailParty | null): CreateBookingParty {
+  if (!p) return emptyParty();
+  return {
+    name: p.name ?? "",
+    address1: p.address1 ?? "",
+    address2: p.address2 ?? "",
+    postalCode: p.postalCode ?? "",
+    city: p.city ?? "",
+    country: p.country ?? "FI",
+    email: p.email ?? "",
+    phoneNumber: p.phoneNumber ?? "",
+    phoneNumberMobile: p.phoneNumberMobile ?? "",
+    contactPersonName: p.contactPersonName ?? "",
+    vatNo: p.vatNo ?? "",
+    customerNumber: p.customerNumber ?? "",
+  };
+}
+
+function partyIsEmptyForPayerInference(p: CreateBookingParty): boolean {
+  return (
+    !(p.name ?? "").trim() &&
+    !(p.address1 ?? "").trim() &&
+    !(p.postalCode ?? "").trim() &&
+    !(p.city ?? "").trim()
+  );
+}
+
+function partiesEqualForPayer(a: CreateBookingParty, b: CreateBookingParty): boolean {
+  const f = (s: string | null | undefined) => (s ?? "").trim();
+  return (
+    f(a.name) === f(b.name) &&
+    f(a.address1) === f(b.address1) &&
+    f(a.address2) === f(b.address2) &&
+    f(a.postalCode) === f(b.postalCode) &&
+    f(a.city) === f(b.city) &&
+    f(a.country) === f(b.country) &&
+    f(a.email) === f(b.email) &&
+    f(a.phoneNumber) === f(b.phoneNumber) &&
+    f(a.phoneNumberMobile) === f(b.phoneNumberMobile) &&
+    f(a.contactPersonName) === f(b.contactPersonName) &&
+    f(a.vatNo) === f(b.vatNo) &&
+    f(a.customerNumber) === f(b.customerNumber)
+  );
+}
+
+/** Infer payer source from stored draft (no explicit flag on booking). */
+export function inferPayerSourceFromBookingDetail(detail: BookingDetail): PayerSource {
+  const shipper = detailPartyToParty(detail.shipper);
+  const receiver = detailPartyToParty(detail.receiver);
+  const payer = detailPartyToParty(detail.payer);
+  if (partyIsEmptyForPayerInference(payer)) return "sender";
+  if (partiesEqualForPayer(payer, shipper)) return "sender";
+  if (partiesEqualForPayer(payer, receiver)) return "receiver";
+  return "other";
+}
+
+/**
+ * Build validation context from API booking/draft detail. Uses `quickBooking: false` so all
+ * non–quick-booking mandatory fields are checked when confirming a draft.
+ */
+export function validationContextFromBookingDetail(
+  detail: BookingDetail,
+  quickBooking = false
+): BookingValidationContext {
+  const packages: CreateBookingPackage[] =
+    detail.packages && detail.packages.length > 0
+      ? detail.packages.map((p) => ({
+          weight: p.weight ?? "",
+          volume: p.volume ?? "",
+          packageType: p.packageType ?? "",
+          description: p.description ?? "",
+          length: p.length ?? "",
+          width: p.width ?? "",
+          height: p.height ?? "",
+        }))
+      : [
+          {
+            weight: "",
+            volume: "",
+            packageType: "",
+            description: "",
+            length: "",
+            width: "",
+            height: "",
+          },
+        ];
+
+  return {
+    postalService: detail.header?.postalService ?? "",
+    shipper: detailPartyToParty(detail.shipper),
+    receiver: detailPartyToParty(detail.receiver),
+    payer: detailPartyToParty(detail.payer),
+    pickUpAddress: detailPartyToParty(detail.pickUpAddress),
+    deliveryPoint: detailPartyToParty(detail.deliveryPoint),
+    payerSource: inferPayerSourceFromBookingDetail(detail),
+    quickBooking,
+    service: detail.shipment?.service ?? "",
+    senderReference: detail.shipment?.senderReference ?? "",
+    receiverReference: detail.shipment?.receiverReference ?? "",
+    freightPayer: detail.shipment?.freightPayer ?? "",
+    handlingInstructions: detail.shipment?.handlingInstructions ?? "",
+    grossWeight: detail.shippingInfo?.grossWeight ?? "",
+    grossVolume: detail.shippingInfo?.grossVolume ?? "",
+    packageQuantity: detail.shippingInfo?.packageQuantity ?? "",
+    pickupHandlingInstructions: detail.shippingInfo?.pickupHandlingInstructions ?? "",
+    deliveryHandlingInstructions: detail.shippingInfo?.deliveryHandlingInstructions ?? "",
+    generalInstructions: detail.shippingInfo?.generalInstructions ?? "",
+    packages,
+  };
 }


### PR DESCRIPTION
- **Create booking:** Save as draft no longer requires mandatory fields; Create booking still validates.\n- **Draft detail:** Confirm runs the same company booking rules as create; shows banner + receiver field errors.\n- **Helpers:** \alidationContextFromBookingDetail\, \inferPayerSourceFromBookingDetail\.\n- **UI:** Validation banner next to create actions; address-book checkbox on its own row above buttons.\n- **i18n:** \alidationActionBanner\ (+ \ieldRequired\ in locales that lacked it).

Made with [Cursor](https://cursor.com)