### PR TITLE
feat(portal): company subscription endpoint and More page pricing

### DIFF
--- a/CargoHub.Api/Controllers/PortalController.cs
+++ b/CargoHub.Api/Controllers/PortalController.cs
@@ -5,6 +5,8 @@ using CargoHub.Application.Auth.Commands;
 using CargoHub.Application.Auth.Dtos;
 using CargoHub.Application.Company;
 using CargoHub.Application.Couriers;
+using CargoHub.Application.Subscriptions;
+using CargoHub.Application.Subscriptions.Queries;
 using CargoHub.Infrastructure.Identity;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -199,6 +201,23 @@ public class PortalController : ControllerBase
             return StatusCode(500, new { message = "Failed to update preferences" });
 
         return Ok(new { theme = user.Theme });
+    }
+
+    /// <summary>Current company subscription plan and pricing (active rate card at UTC now). User must be linked to a company.</summary>
+    [HttpGet("company/subscription")]
+    [Authorize]
+    public async Task<ActionResult<PortalCompanySubscriptionDto>> GetCompanySubscription(CancellationToken cancellationToken)
+    {
+        var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (string.IsNullOrEmpty(userId))
+            return Unauthorized();
+        var user = await _userManager.FindByIdAsync(userId);
+        if (string.IsNullOrWhiteSpace(user?.BusinessId))
+            return NotFound();
+        var dto = await _mediator.Send(new GetPortalCompanySubscriptionQuery(user.BusinessId.Trim()), cancellationToken);
+        if (dto == null)
+            return NotFound();
+        return Ok(dto);
     }
 
     /// <summary>Request password reset; sends token (email sending optional). Body: { email }.</summary>

--- a/CargoHub.Api/Program.cs
+++ b/CargoHub.Api/Program.cs
@@ -8,6 +8,7 @@ using CargoHub.Application.Billing;
 using CargoHub.Application.Bookings;
 using CargoHub.Application.AdminCompanies;
 using CargoHub.Application.Company;
+using CargoHub.Application.Subscriptions;
 using CargoHub.Infrastructure.Auth;
 using CargoHub.Infrastructure.Company;
 using CargoHub.Infrastructure.Billing;
@@ -104,6 +105,7 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 builder.Services.AddScoped<IJwtTokenFactory, JwtTokenFactory>();
 builder.Services.Configure<PortalPublicOptions>(builder.Configuration.GetSection(PortalPublicOptions.SectionName));
 builder.Services.AddScoped<ICompanyRepository, CompanyRepository>();
+builder.Services.AddScoped<IPortalCompanySubscriptionReader, PortalCompanySubscriptionReader>();
 builder.Services.AddScoped<ICompanyAdminInviteRepository, CompanyAdminInviteRepository>();
 builder.Services.AddScoped<ICompanyUserMetrics, CompanyUserMetrics>();
 builder.Services.AddScoped<ICompanyAdminInviteIssuer, CompanyAdminInviteIssuer>();

--- a/CargoHub.Application/Subscriptions/IPortalCompanySubscriptionReader.cs
+++ b/CargoHub.Application/Subscriptions/IPortalCompanySubscriptionReader.cs
@@ -1,0 +1,7 @@
+namespace CargoHub.Application.Subscriptions;
+
+public interface IPortalCompanySubscriptionReader
+{
+    /// <summary>Loads plan and current pricing period for the company with this business ID, or null if no company.</summary>
+    Task<PortalCompanySubscriptionDto?> GetForBusinessIdAsync(string businessId, CancellationToken cancellationToken = default);
+}

--- a/CargoHub.Application/Subscriptions/PortalCompanySubscriptionDto.cs
+++ b/CargoHub.Application/Subscriptions/PortalCompanySubscriptionDto.cs
@@ -1,0 +1,35 @@
+namespace CargoHub.Application.Subscriptions;
+
+/// <summary>Portal-facing subscription snapshot for the current company (rates from the active pricing period at UTC now).</summary>
+public sealed class PortalCompanySubscriptionDto
+{
+    public string PlanName { get; init; } = "";
+
+    /// <summary>Subscription plan kind name (matches <c>SubscriptionPlanKind</c> enum).</summary>
+    public string PlanKind { get; init; } = "";
+
+    public string Currency { get; init; } = "EUR";
+
+    public int? TrialBookingAllowance { get; init; }
+
+    public decimal? ChargePerBooking { get; init; }
+
+    public decimal? MonthlyFee { get; init; }
+
+    public int? IncludedBookingsPerMonth { get; init; }
+
+    public decimal? OverageChargePerBooking { get; init; }
+
+    public IReadOnlyList<PortalSubscriptionTierDto>? Tiers { get; init; }
+}
+
+public sealed class PortalSubscriptionTierDto
+{
+    public int Ordinal { get; init; }
+
+    public int? InclusiveMaxBookingsInPeriod { get; init; }
+
+    public decimal? ChargePerBooking { get; init; }
+
+    public decimal? MonthlyFee { get; init; }
+}

--- a/CargoHub.Application/Subscriptions/Queries/GetPortalCompanySubscriptionQuery.cs
+++ b/CargoHub.Application/Subscriptions/Queries/GetPortalCompanySubscriptionQuery.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace CargoHub.Application.Subscriptions.Queries;
+
+public sealed record GetPortalCompanySubscriptionQuery(string BusinessId) : IRequest<PortalCompanySubscriptionDto?>;

--- a/CargoHub.Application/Subscriptions/Queries/GetPortalCompanySubscriptionQueryHandler.cs
+++ b/CargoHub.Application/Subscriptions/Queries/GetPortalCompanySubscriptionQueryHandler.cs
@@ -1,0 +1,16 @@
+using MediatR;
+
+namespace CargoHub.Application.Subscriptions.Queries;
+
+public sealed class GetPortalCompanySubscriptionQueryHandler : IRequestHandler<GetPortalCompanySubscriptionQuery, PortalCompanySubscriptionDto?>
+{
+    private readonly IPortalCompanySubscriptionReader _reader;
+
+    public GetPortalCompanySubscriptionQueryHandler(IPortalCompanySubscriptionReader reader)
+    {
+        _reader = reader;
+    }
+
+    public Task<PortalCompanySubscriptionDto?> Handle(GetPortalCompanySubscriptionQuery request, CancellationToken cancellationToken) =>
+        _reader.GetForBusinessIdAsync(request.BusinessId, cancellationToken);
+}

--- a/CargoHub.Infrastructure/Persistence/PortalCompanySubscriptionReader.cs
+++ b/CargoHub.Infrastructure/Persistence/PortalCompanySubscriptionReader.cs
@@ -1,0 +1,87 @@
+using CargoHub.Application.Subscriptions;
+using CargoHub.Domain.Billing;
+using Microsoft.EntityFrameworkCore;
+
+namespace CargoHub.Infrastructure.Persistence;
+
+public sealed class PortalCompanySubscriptionReader : IPortalCompanySubscriptionReader
+{
+    private readonly ApplicationDbContext _db;
+
+    public PortalCompanySubscriptionReader(ApplicationDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<PortalCompanySubscriptionDto?> GetForBusinessIdAsync(string businessId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(businessId))
+            return null;
+
+        var bid = businessId.Trim();
+        var company = await _db.Companies.AsNoTracking()
+            .FirstOrDefaultAsync(
+                c => c.BusinessId != null && c.BusinessId.Trim().ToLower() == bid.ToLowerInvariant(),
+                cancellationToken);
+        if (company == null)
+            return null;
+
+        if (company.SubscriptionPlanId is not { } planId)
+        {
+            return new PortalCompanySubscriptionDto
+            {
+                PlanName = "",
+                PlanKind = "None",
+                Currency = "EUR"
+            };
+        }
+
+        var plan = await _db.SubscriptionPlans.AsNoTracking()
+            .Include(p => p.PricingPeriods)
+            .ThenInclude(pp => pp.Tiers)
+            .FirstOrDefaultAsync(p => p.Id == planId, cancellationToken);
+
+        if (plan == null)
+        {
+            return new PortalCompanySubscriptionDto
+            {
+                PlanName = "",
+                PlanKind = "Unknown",
+                Currency = "EUR"
+            };
+        }
+
+        var instant = DateTime.UtcNow;
+        var period = plan.PricingPeriods
+            .Where(pp => pp.EffectiveFromUtc <= instant)
+            .OrderByDescending(pp => pp.EffectiveFromUtc)
+            .FirstOrDefault();
+
+        IReadOnlyList<PortalSubscriptionTierDto>? tiers = null;
+        if (period?.Tiers is { Count: > 0 } t)
+        {
+            tiers = t.OrderBy(x => x.Ordinal)
+                .Select(x => new PortalSubscriptionTierDto
+                {
+                    Ordinal = x.Ordinal,
+                    InclusiveMaxBookingsInPeriod = x.InclusiveMaxBookingsInPeriod,
+                    ChargePerBooking = x.ChargePerBooking,
+                    MonthlyFee = x.MonthlyFee
+                })
+                .ToList();
+        }
+
+        return new PortalCompanySubscriptionDto
+        {
+            PlanName = plan.Name,
+            PlanKind = plan.Kind.ToString(),
+            Currency = plan.Currency,
+            TrialBookingAllowance = plan.Kind == SubscriptionPlanKind.Trial ? plan.TrialBookingAllowance : null,
+            ChargePerBooking = period?.ChargePerBooking,
+            MonthlyFee = period?.MonthlyFee,
+            IncludedBookingsPerMonth = period?.IncludedBookingsPerMonth,
+            OverageChargePerBooking = period?.OverageChargePerBooking,
+            Tiers = tiers
+        };
+    }
+}

--- a/CargoHub.Tests/Subscriptions/GetPortalCompanySubscriptionQueryHandlerTests.cs
+++ b/CargoHub.Tests/Subscriptions/GetPortalCompanySubscriptionQueryHandlerTests.cs
@@ -1,0 +1,20 @@
+using CargoHub.Application.Subscriptions;
+using CargoHub.Application.Subscriptions.Queries;
+using Moq;
+using Xunit;
+
+namespace CargoHub.Tests.Subscriptions;
+
+public class GetPortalCompanySubscriptionQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_DelegatesToReader()
+    {
+        var expected = new PortalCompanySubscriptionDto { PlanName = "Trial", PlanKind = "Trial", Currency = "EUR" };
+        var reader = new Mock<IPortalCompanySubscriptionReader>();
+        reader.Setup(r => r.GetForBusinessIdAsync("B1", It.IsAny<CancellationToken>())).ReturnsAsync(expected);
+        var h = new GetPortalCompanySubscriptionQueryHandler(reader.Object);
+        var r = await h.Handle(new GetPortalCompanySubscriptionQuery("B1"), default);
+        Assert.Same(expected, r);
+    }
+}

--- a/CargoHub.Tests/Subscriptions/PortalCompanySubscriptionReaderTests.cs
+++ b/CargoHub.Tests/Subscriptions/PortalCompanySubscriptionReaderTests.cs
@@ -1,0 +1,353 @@
+using CargoHub.Domain.Billing;
+using CargoHub.Domain.Companies;
+using CargoHub.Infrastructure.Persistence;
+using Xunit;
+using CompanyEntity = CargoHub.Domain.Companies.Company;
+
+namespace CargoHub.Tests.Subscriptions;
+
+public class PortalCompanySubscriptionReaderTests : IDisposable
+{
+    private readonly TestDbFixture _fixture;
+
+    public PortalCompanySubscriptionReaderTests()
+    {
+        _fixture = new TestDbFixture();
+    }
+
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public async Task GetForBusinessIdAsync_NullOrWhiteSpace_ReturnsNull()
+    {
+        using var ctx = _fixture.CreateContext();
+        var reader = new PortalCompanySubscriptionReader(ctx);
+        Assert.Null(await reader.GetForBusinessIdAsync(null!));
+        Assert.Null(await reader.GetForBusinessIdAsync(""));
+        Assert.Null(await reader.GetForBusinessIdAsync("   "));
+    }
+
+    [Fact]
+    public async Task GetForBusinessIdAsync_CompanyMissing_ReturnsNull()
+    {
+        using var ctx = _fixture.CreateContext();
+        var reader = new PortalCompanySubscriptionReader(ctx);
+        Assert.Null(await reader.GetForBusinessIdAsync("no-such-biz"));
+    }
+
+    [Fact]
+    public async Task GetForBusinessIdAsync_NoPlanAssigned_ReturnsNone()
+    {
+        using var ctx = _fixture.CreateContext();
+        var company = new CompanyEntity
+        {
+            Id = Guid.NewGuid(),
+            CompanyId = "c-none",
+            Name = "No Plan Oy",
+            BusinessId = "1111111-1",
+            CustomerId = "cust"
+        };
+        ctx.Companies.Add(company);
+        await ctx.SaveChangesAsync();
+
+        var reader = new PortalCompanySubscriptionReader(ctx);
+        var dto = await reader.GetForBusinessIdAsync("1111111-1");
+        Assert.NotNull(dto);
+        Assert.Equal("None", dto.PlanKind);
+        Assert.Equal("", dto.PlanName);
+        Assert.Null(dto.TrialBookingAllowance);
+    }
+
+    [Fact]
+    public async Task GetForBusinessIdAsync_PlanRowMissing_ReturnsUnknown()
+    {
+        using var ctx = _fixture.CreateContext();
+        var orphanPlanId = Guid.NewGuid();
+        var company = new CompanyEntity
+        {
+            Id = Guid.NewGuid(),
+            CompanyId = "c-orphan",
+            Name = "Orphan Oy",
+            BusinessId = "2222222-2",
+            CustomerId = "cust",
+            SubscriptionPlanId = orphanPlanId
+        };
+        ctx.Companies.Add(company);
+        await ctx.SaveChangesAsync();
+
+        var reader = new PortalCompanySubscriptionReader(ctx);
+        var dto = await reader.GetForBusinessIdAsync("2222222-2");
+        Assert.NotNull(dto);
+        Assert.Equal("Unknown", dto.PlanKind);
+    }
+
+    [Fact]
+    public async Task GetForBusinessIdAsync_MatchesBusinessIdCaseInsensitively()
+    {
+        using var ctx = _fixture.CreateContext();
+        var company = new CompanyEntity
+        {
+            Id = Guid.NewGuid(),
+            CompanyId = "c-case",
+            Name = "Case Oy",
+            BusinessId = "Ab-12",
+            CustomerId = "cust"
+        };
+        ctx.Companies.Add(company);
+        await ctx.SaveChangesAsync();
+
+        var reader = new PortalCompanySubscriptionReader(ctx);
+        var dto = await reader.GetForBusinessIdAsync("  ab-12 ");
+        Assert.NotNull(dto);
+        Assert.Equal("None", dto.PlanKind);
+    }
+
+    [Fact]
+    public async Task GetForBusinessIdAsync_TrialPlan_IncludesAllowanceAndPeriodFields()
+    {
+        using var ctx = _fixture.CreateContext();
+        var planId = Guid.NewGuid();
+        var periodId = Guid.NewGuid();
+        var plan = new SubscriptionPlan
+        {
+            Id = planId,
+            Name = "Trial X",
+            Kind = SubscriptionPlanKind.Trial,
+            TrialBookingAllowance = 7,
+            Currency = "SEK",
+            PricingPeriods =
+            {
+                new SubscriptionPlanPricingPeriod
+                {
+                    Id = periodId,
+                    SubscriptionPlanId = planId,
+                    EffectiveFromUtc = DateTime.UtcNow.AddDays(-1),
+                    ChargePerBooking = 1.5m,
+                    MonthlyFee = 9.99m,
+                    IncludedBookingsPerMonth = 10,
+                    OverageChargePerBooking = 2m
+                }
+            }
+        };
+        ctx.SubscriptionPlans.Add(plan);
+        var company = new CompanyEntity
+        {
+            Id = Guid.NewGuid(),
+            CompanyId = "c-trial",
+            Name = "Trial Oy",
+            BusinessId = "3333333-3",
+            CustomerId = "cust",
+            SubscriptionPlanId = planId
+        };
+        ctx.Companies.Add(company);
+        await ctx.SaveChangesAsync();
+
+        var reader = new PortalCompanySubscriptionReader(ctx);
+        var dto = await reader.GetForBusinessIdAsync("3333333-3");
+        Assert.NotNull(dto);
+        Assert.Equal("Trial", dto.PlanKind);
+        Assert.Equal(7, dto.TrialBookingAllowance);
+        Assert.Equal("Trial X", dto.PlanName);
+        Assert.Equal("SEK", dto.Currency);
+        Assert.Equal(1.5m, dto.ChargePerBooking);
+        Assert.Equal(9.99m, dto.MonthlyFee);
+        Assert.Equal(10, dto.IncludedBookingsPerMonth);
+        Assert.Equal(2m, dto.OverageChargePerBooking);
+        Assert.Null(dto.Tiers);
+    }
+
+    [Fact]
+    public async Task GetForBusinessIdAsync_NonTrial_OmitsTrialAllowance()
+    {
+        using var ctx = _fixture.CreateContext();
+        var planId = Guid.NewGuid();
+        var plan = new SubscriptionPlan
+        {
+            Id = planId,
+            Name = "PayGo",
+            Kind = SubscriptionPlanKind.PayPerBooking,
+            TrialBookingAllowance = 99,
+            Currency = "EUR",
+            PricingPeriods =
+            {
+                new SubscriptionPlanPricingPeriod
+                {
+                    Id = Guid.NewGuid(),
+                    SubscriptionPlanId = planId,
+                    EffectiveFromUtc = DateTime.UtcNow.AddHours(-1),
+                    ChargePerBooking = 3m
+                }
+            }
+        };
+        ctx.SubscriptionPlans.Add(plan);
+        var company = new CompanyEntity
+        {
+            Id = Guid.NewGuid(),
+            CompanyId = "c-pay",
+            Name = "Pay Oy",
+            BusinessId = "4444444-4",
+            CustomerId = "cust",
+            SubscriptionPlanId = planId
+        };
+        ctx.Companies.Add(company);
+        await ctx.SaveChangesAsync();
+
+        var reader = new PortalCompanySubscriptionReader(ctx);
+        var dto = await reader.GetForBusinessIdAsync("4444444-4");
+        Assert.NotNull(dto);
+        Assert.Equal("PayPerBooking", dto.PlanKind);
+        Assert.Null(dto.TrialBookingAllowance);
+        Assert.Equal(3m, dto.ChargePerBooking);
+    }
+
+    [Fact]
+    public async Task GetForBusinessIdAsync_NoEffectivePeriod_YieldsNullPeriodFields()
+    {
+        using var ctx = _fixture.CreateContext();
+        var planId = Guid.NewGuid();
+        var plan = new SubscriptionPlan
+        {
+            Id = planId,
+            Name = "Future",
+            Kind = SubscriptionPlanKind.MonthlyBundle,
+            Currency = "EUR",
+            PricingPeriods =
+            {
+                new SubscriptionPlanPricingPeriod
+                {
+                    Id = Guid.NewGuid(),
+                    SubscriptionPlanId = planId,
+                    EffectiveFromUtc = DateTime.UtcNow.AddDays(30),
+                    MonthlyFee = 100m
+                }
+            }
+        };
+        ctx.SubscriptionPlans.Add(plan);
+        var company = new CompanyEntity
+        {
+            Id = Guid.NewGuid(),
+            CompanyId = "c-fut",
+            Name = "Future Oy",
+            BusinessId = "5555555-5",
+            CustomerId = "cust",
+            SubscriptionPlanId = planId
+        };
+        ctx.Companies.Add(company);
+        await ctx.SaveChangesAsync();
+
+        var reader = new PortalCompanySubscriptionReader(ctx);
+        var dto = await reader.GetForBusinessIdAsync("5555555-5");
+        Assert.NotNull(dto);
+        Assert.Null(dto.ChargePerBooking);
+        Assert.Null(dto.MonthlyFee);
+        Assert.Null(dto.Tiers);
+    }
+
+    [Fact]
+    public async Task GetForBusinessIdAsync_TiersOrderedByOrdinal()
+    {
+        using var ctx = _fixture.CreateContext();
+        var planId = Guid.NewGuid();
+        var periodId = Guid.NewGuid();
+        var plan = new SubscriptionPlan
+        {
+            Id = planId,
+            Name = "Tiered",
+            Kind = SubscriptionPlanKind.TieredPayPerBooking,
+            Currency = "EUR",
+            PricingPeriods =
+            {
+                new SubscriptionPlanPricingPeriod
+                {
+                    Id = periodId,
+                    SubscriptionPlanId = planId,
+                    EffectiveFromUtc = DateTime.UtcNow.AddDays(-2),
+                    Tiers =
+                    {
+                        new SubscriptionPlanPricingTier
+                        {
+                            Id = Guid.NewGuid(),
+                            SubscriptionPlanPricingPeriodId = periodId,
+                            Ordinal = 2,
+                            InclusiveMaxBookingsInPeriod = 20,
+                            ChargePerBooking = 2m
+                        },
+                        new SubscriptionPlanPricingTier
+                        {
+                            Id = Guid.NewGuid(),
+                            SubscriptionPlanPricingPeriodId = periodId,
+                            Ordinal = 1,
+                            InclusiveMaxBookingsInPeriod = 10,
+                            ChargePerBooking = 1m
+                        }
+                    }
+                }
+            }
+        };
+        ctx.SubscriptionPlans.Add(plan);
+        var company = new CompanyEntity
+        {
+            Id = Guid.NewGuid(),
+            CompanyId = "c-tier",
+            Name = "Tier Oy",
+            BusinessId = "6666666-6",
+            CustomerId = "cust",
+            SubscriptionPlanId = planId
+        };
+        ctx.Companies.Add(company);
+        await ctx.SaveChangesAsync();
+
+        var reader = new PortalCompanySubscriptionReader(ctx);
+        var dto = await reader.GetForBusinessIdAsync("6666666-6");
+        Assert.NotNull(dto);
+        Assert.NotNull(dto.Tiers);
+        Assert.Equal(2, dto.Tiers!.Count);
+        Assert.Equal(1, dto.Tiers[0].Ordinal);
+        Assert.Equal(10, dto.Tiers[0].InclusiveMaxBookingsInPeriod);
+        Assert.Equal(2, dto.Tiers[1].Ordinal);
+    }
+
+    [Fact]
+    public async Task GetForBusinessIdAsync_PeriodWithEmptyTiers_YieldsNullTiers()
+    {
+        using var ctx = _fixture.CreateContext();
+        var planId = Guid.NewGuid();
+        var periodId = Guid.NewGuid();
+        var plan = new SubscriptionPlan
+        {
+            Id = planId,
+            Name = "Flat",
+            Kind = SubscriptionPlanKind.PayPerBooking,
+            Currency = "EUR",
+            PricingPeriods =
+            {
+                new SubscriptionPlanPricingPeriod
+                {
+                    Id = periodId,
+                    SubscriptionPlanId = planId,
+                    EffectiveFromUtc = DateTime.UtcNow.AddDays(-1),
+                    ChargePerBooking = 5m,
+                    Tiers = new List<SubscriptionPlanPricingTier>()
+                }
+            }
+        };
+        ctx.SubscriptionPlans.Add(plan);
+        var company = new CompanyEntity
+        {
+            Id = Guid.NewGuid(),
+            CompanyId = "c-flat",
+            Name = "Flat Oy",
+            BusinessId = "7777777-7",
+            CustomerId = "cust",
+            SubscriptionPlanId = planId
+        };
+        ctx.Companies.Add(company);
+        await ctx.SaveChangesAsync();
+
+        var reader = new PortalCompanySubscriptionReader(ctx);
+        var dto = await reader.GetForBusinessIdAsync("7777777-7");
+        Assert.NotNull(dto);
+        Assert.Null(dto.Tiers);
+        Assert.Equal(5m, dto.ChargePerBooking);
+    }
+}

--- a/portal/messages/da.json
+++ b/portal/messages/da.json
@@ -250,6 +250,26 @@
     "language": "Sprog",
     "comingSoon": "Flere muligheder kommer snart.",
     "courierContracts": "Courier contracts",
-    "courierContractsHint": "Choose carriers and contract IDs for bookings."
+    "courierContractsHint": "Choose carriers and contract IDs for bookings.",
+    "signedInAs": "Logget ind som",
+    "companyLabel": "Virksomhed",
+    "subscriptionTitle": "Abonnement",
+    "subscriptionPlanLabel": "Navn",
+    "subscriptionPricingLabel": "Priser",
+    "subscriptionUnnamedPlan": "Abonnementsplan",
+    "subscriptionNonePlan": "Der er endnu ikke tildelt en abonnementsplan.",
+    "subscriptionUnknownPlan": "Abonnementsoplysninger er ikke tilgængelige.",
+    "subscriptionTrial": "Prøveabonnement.",
+    "subscriptionTrialBookings": "Op til {count} bookinger inkluderet i prøveperioden.",
+    "subscriptionPerBooking": "{amount} pr. gennemført booking.",
+    "subscriptionRatesPending": "Detaljerede priser vises, når de er konfigureret.",
+    "subscriptionMonthlyBase": "Månedlig grundpris: {amount}.",
+    "subscriptionIncludedBookings": "{count} bookinger inkluderet pr. måned.",
+    "subscriptionOverageEach": "Yderligere bookinger: {amount} pr. stk.",
+    "subscriptionTierBandMax": "Op til {max} bookinger i perioden",
+    "subscriptionTierBandOpen": "Ud over tidligere niveauer",
+    "subscriptionPerBookingShort": "pr. booking",
+    "subscriptionPerMonthShort": "pr. måned",
+    "subscriptionLoadError": "Kunne ikke indlæse abonnementet."
   }
 }

--- a/portal/messages/en.json
+++ b/portal/messages/en.json
@@ -398,6 +398,26 @@
     "language": "Language",
     "comingSoon": "More options coming soon.",
     "courierContracts": "Courier contracts",
-    "courierContractsHint": "Choose carriers and contract IDs for bookings."
+    "courierContractsHint": "Choose carriers and contract IDs for bookings.",
+    "signedInAs": "Signed in as",
+    "companyLabel": "Company",
+    "subscriptionTitle": "Subscription",
+    "subscriptionPlanLabel": "Name",
+    "subscriptionPricingLabel": "Pricing",
+    "subscriptionUnnamedPlan": "Subscription plan",
+    "subscriptionNonePlan": "No subscription plan is assigned yet.",
+    "subscriptionUnknownPlan": "Subscription details are unavailable.",
+    "subscriptionTrial": "Trial subscription.",
+    "subscriptionTrialBookings": "Up to {count} bookings included during the trial.",
+    "subscriptionPerBooking": "{amount} per completed booking.",
+    "subscriptionRatesPending": "Detailed rates will appear when configured.",
+    "subscriptionMonthlyBase": "Monthly base: {amount}.",
+    "subscriptionIncludedBookings": "{count} bookings included per month.",
+    "subscriptionOverageEach": "Additional bookings: {amount} each.",
+    "subscriptionTierBandMax": "Up to {max} bookings in the period",
+    "subscriptionTierBandOpen": "Beyond previous tiers",
+    "subscriptionPerBookingShort": "per booking",
+    "subscriptionPerMonthShort": "per month",
+    "subscriptionLoadError": "Could not load subscription."
   }
 }

--- a/portal/messages/fi.json
+++ b/portal/messages/fi.json
@@ -353,6 +353,26 @@
     "language": "Kieli",
     "comingSoon": "Lisää vaihtoehtoja tulossa.",
     "courierContracts": "Kuljetussopimukset",
-    "courierContractsHint": "Valitse kuljetusliikkeet ja sopimustunnukset varauksia varten."
+    "courierContractsHint": "Valitse kuljetusliikkeet ja sopimustunnukset varauksia varten.",
+    "signedInAs": "Kirjautunut käyttäjänä",
+    "companyLabel": "Yritys",
+    "subscriptionTitle": "Tilaus",
+    "subscriptionPlanLabel": "Nimi",
+    "subscriptionPricingLabel": "Hinnoittelu",
+    "subscriptionUnnamedPlan": "Tilaussuunnitelma",
+    "subscriptionNonePlan": "Tilaussuunnitelmaa ei ole vielä määritetty.",
+    "subscriptionUnknownPlan": "Tilaustietoja ei ole saatavilla.",
+    "subscriptionTrial": "Kokeilujakso.",
+    "subscriptionTrialBookings": "Enintään {count} varausta kokeilujaksolla.",
+    "subscriptionPerBooking": "{amount} per valmis varaus.",
+    "subscriptionRatesPending": "Tarkat hinnat näytetään, kun ne on määritetty.",
+    "subscriptionMonthlyBase": "Kuukausimaksu: {amount}.",
+    "subscriptionIncludedBookings": "{count} varausta kuukaudessa.",
+    "subscriptionOverageEach": "Lisävaraukset: {amount} kpl.",
+    "subscriptionTierBandMax": "Enintään {max} varausta jaksolla",
+    "subscriptionTierBandOpen": "Aiempien tasojen yläpuolella",
+    "subscriptionPerBookingShort": "per varaus",
+    "subscriptionPerMonthShort": "kuukaudessa",
+    "subscriptionLoadError": "Tilauksen lataus epäonnistui."
   }
 }

--- a/portal/messages/is.json
+++ b/portal/messages/is.json
@@ -250,6 +250,26 @@
     "language": "Tungumál",
     "comingSoon": "Fleiri valkostir koma fljótlega.",
     "courierContracts": "Courier contracts",
-    "courierContractsHint": "Choose carriers and contract IDs for bookings."
+    "courierContractsHint": "Choose carriers and contract IDs for bookings.",
+    "signedInAs": "Skráð(ur) inn sem",
+    "companyLabel": "Fyrirtæki",
+    "subscriptionTitle": "Áskrift",
+    "subscriptionPlanLabel": "Heiti",
+    "subscriptionPricingLabel": "Verðlagning",
+    "subscriptionUnnamedPlan": "Áskriftaráætlun",
+    "subscriptionNonePlan": "Engin áskriftaráætlun hefur verið úthlutað enn.",
+    "subscriptionUnknownPlan": "Áskriftarupplýsingar eru ekki tiltækar.",
+    "subscriptionTrial": "Prufuáskrift.",
+    "subscriptionTrialBookings": "Allt að {count} bókanir innifaldar á prufutímabilinu.",
+    "subscriptionPerBooking": "{amount} á hverja lokaða bókun.",
+    "subscriptionRatesPending": "Nánari verð birtast þegar þau hafa verið stillt.",
+    "subscriptionMonthlyBase": "Mánaðarleg grunnupphæð: {amount}.",
+    "subscriptionIncludedBookings": "{count} bókanir innifaldar á mánuði.",
+    "subscriptionOverageEach": "Viðbótarbókanir: {amount} hver.",
+    "subscriptionTierBandMax": "Allt að {max} bókanir á tímabilinu",
+    "subscriptionTierBandOpen": "Umfram fyrri þrep",
+    "subscriptionPerBookingShort": "á bókun",
+    "subscriptionPerMonthShort": "á mánuði",
+    "subscriptionLoadError": "Ekki tókst að sækja áskriftina."
   }
 }

--- a/portal/messages/no.json
+++ b/portal/messages/no.json
@@ -250,6 +250,26 @@
     "language": "Språk",
     "comingSoon": "Flere alternativer kommer snart.",
     "courierContracts": "Courier contracts",
-    "courierContractsHint": "Choose carriers and contract IDs for bookings."
+    "courierContractsHint": "Choose carriers and contract IDs for bookings.",
+    "signedInAs": "Logget inn som",
+    "companyLabel": "Bedrift",
+    "subscriptionTitle": "Abonnement",
+    "subscriptionPlanLabel": "Navn",
+    "subscriptionPricingLabel": "Priser",
+    "subscriptionUnnamedPlan": "Abonnementsplan",
+    "subscriptionNonePlan": "Ingen abonnementsplan er tildelt ennå.",
+    "subscriptionUnknownPlan": "Abonnementsinformasjon er ikke tilgjengelig.",
+    "subscriptionTrial": "Prøveabonnement.",
+    "subscriptionTrialBookings": "Opptil {count} bookinger inkludert i prøveperioden.",
+    "subscriptionPerBooking": "{amount} per fullført booking.",
+    "subscriptionRatesPending": "Detaljerte priser vises når de er konfigurert.",
+    "subscriptionMonthlyBase": "Månedlig grunnpris: {amount}.",
+    "subscriptionIncludedBookings": "{count} bookinger inkludert per måned.",
+    "subscriptionOverageEach": "Tilleggsbookinger: {amount} hver.",
+    "subscriptionTierBandMax": "Opptil {max} bookinger i perioden",
+    "subscriptionTierBandOpen": "Utover tidligere nivåer",
+    "subscriptionPerBookingShort": "per booking",
+    "subscriptionPerMonthShort": "per måned",
+    "subscriptionLoadError": "Kunne ikke laste abonnementet."
   }
 }

--- a/portal/messages/sv.json
+++ b/portal/messages/sv.json
@@ -250,6 +250,26 @@
     "language": "Språk",
     "comingSoon": "Fler alternativ kommer snart.",
     "courierContracts": "Courier contracts",
-    "courierContractsHint": "Choose carriers and contract IDs for bookings."
+    "courierContractsHint": "Choose carriers and contract IDs for bookings.",
+    "signedInAs": "Inloggad som",
+    "companyLabel": "Företag",
+    "subscriptionTitle": "Prenumeration",
+    "subscriptionPlanLabel": "Namn",
+    "subscriptionPricingLabel": "Pris",
+    "subscriptionUnnamedPlan": "Prenumerationsplan",
+    "subscriptionNonePlan": "Ingen prenumerationsplan har tilldelats ännu.",
+    "subscriptionUnknownPlan": "Prenumerationsuppgifter är inte tillgängliga.",
+    "subscriptionTrial": "Provperiod.",
+    "subscriptionTrialBookings": "Upp till {count} bokningar ingår under provperioden.",
+    "subscriptionPerBooking": "{amount} per slutförd bokning.",
+    "subscriptionRatesPending": "Detaljerade priser visas när de konfigurerats.",
+    "subscriptionMonthlyBase": "Månadsavgift: {amount}.",
+    "subscriptionIncludedBookings": "{count} bokningar ingår per månad.",
+    "subscriptionOverageEach": "Ytterligare bokningar: {amount} styck.",
+    "subscriptionTierBandMax": "Upp till {max} bokningar under perioden",
+    "subscriptionTierBandOpen": "Utöver tidigare nivåer",
+    "subscriptionPerBookingShort": "per bokning",
+    "subscriptionPerMonthShort": "per månad",
+    "subscriptionLoadError": "Kunde inte ladda prenumerationen."
   }
 }

--- a/portal/src/app/[locale]/(protected)/more/page.test.tsx
+++ b/portal/src/app/[locale]/(protected)/more/page.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@/test/test-utils";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@/test/test-utils";
 import MorePage from "./page";
 
 const mockUseAuth = vi.fn();
@@ -16,9 +16,19 @@ vi.mock("@/context/AuthContext", () => ({
   useAuth: () => mockUseAuth(),
 }));
 
+const mockGetCompanySubscription = vi.fn();
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    getCompanySubscription: (...args: unknown[]) => mockGetCompanySubscription(...args),
+  };
+});
+
 describe("MorePage", () => {
   beforeEach(() => {
     mockUseAuth.mockClear();
+    mockGetCompanySubscription.mockReset();
   });
 
   it("renders title and signed in info with email", () => {
@@ -42,8 +52,32 @@ describe("MorePage", () => {
   });
 
   it("renders company businessId when present", () => {
-    mockUseAuth.mockReturnValue({ user: { email: "u@x.com", businessId: "1234567-8" } });
+    mockUseAuth.mockReturnValue({ user: { email: "u@x.com", businessId: "1234567-8" }, token: null });
     render(<MorePage />);
-    expect(screen.getByText(/Company: 1234567-8/)).toBeInTheDocument();
+    expect(screen.getByText(/companyLabel/)).toBeInTheDocument();
+    expect(screen.getByText(/1234567-8/)).toBeInTheDocument();
+  });
+
+  it("loads and shows subscription name and pricing when token and businessId exist", async () => {
+    mockGetCompanySubscription.mockResolvedValue({
+      planName: "Trial",
+      planKind: "Trial",
+      currency: "EUR",
+      trialBookingAllowance: 5,
+    });
+    mockUseAuth.mockReturnValue({
+      user: { email: "u@x.com", businessId: "BIZ-1" },
+      token: "jwt",
+    });
+    render(<MorePage />);
+    await waitFor(() => {
+      expect(mockGetCompanySubscription).toHaveBeenCalledWith("jwt");
+    });
+    await waitFor(() => {
+      expect(screen.getByText("subscriptionTitle")).toBeInTheDocument();
+      expect(screen.getByText("Trial")).toBeInTheDocument();
+      expect(screen.getByText("subscriptionPlanLabel")).toBeInTheDocument();
+      expect(screen.getByText("subscriptionPricingLabel")).toBeInTheDocument();
+    });
   });
 });

--- a/portal/src/app/[locale]/(protected)/more/page.tsx
+++ b/portal/src/app/[locale]/(protected)/more/page.tsx
@@ -5,12 +5,49 @@ import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { useEffect, useState } from "react";
+import { getCompanySubscription, type PortalCompanySubscriptionDto } from "@/lib/api";
+import { buildSubscriptionPricingLines } from "@/lib/subscription-pricing";
 
 export default function MorePage() {
-  const { user } = useAuth();
+  const { user, token } = useAuth();
   const t = useTranslations("more");
   const roles = user?.roles ?? [];
   const isSuperAdmin = Array.isArray(roles) && roles.includes("SuperAdmin");
+  const [subscription, setSubscription] = useState<PortalCompanySubscriptionDto | null>(null);
+  const [subscriptionError, setSubscriptionError] = useState(false);
+
+  useEffect(() => {
+    if (!token || !user?.businessId) {
+      setSubscription(null);
+      setSubscriptionError(false);
+      return;
+    }
+    let cancelled = false;
+    setSubscriptionError(false);
+    getCompanySubscription(token)
+      .then((d) => {
+        if (!cancelled) setSubscription(d);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setSubscription(null);
+          setSubscriptionError(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token, user?.businessId]);
+
+  const pricingLines =
+    subscription != null
+      ? buildSubscriptionPricingLines(subscription, (key, values) => {
+          // All keys exist under `more` in messages; cast avoids strict key union drift.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic keys from buildSubscriptionPricingLines
+          return (t as any)(key, values);
+        })
+      : [];
 
   return (
     <div className="space-y-6">
@@ -22,10 +59,41 @@ export default function MorePage() {
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="rounded-lg border p-4 space-y-1">
-            <p className="text-sm font-medium">Signed in as</p>
+            <p className="text-sm font-medium">{t("signedInAs")}</p>
             <p className="text-sm text-muted-foreground">{user?.email ?? user?.displayName ?? "—"}</p>
             {user?.businessId && (
-              <p className="text-sm text-muted-foreground">Company: {user.businessId}</p>
+              <p className="text-sm text-muted-foreground">
+                {t("companyLabel")}: {user.businessId}
+              </p>
+            )}
+            {user?.businessId && (subscription != null || subscriptionError) && (
+              <div className="mt-4 space-y-3 border-t border-border pt-4">
+                <p className="text-sm font-medium">{t("subscriptionTitle")}</p>
+                {subscriptionError ? (
+                  <p className="text-sm text-muted-foreground">{t("subscriptionLoadError")}</p>
+                ) : subscription != null ? (
+                  <>
+                    <div className="space-y-1">
+                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        {t("subscriptionPlanLabel")}
+                      </p>
+                      <p className="text-sm text-foreground">
+                        {subscription.planName?.trim() ? subscription.planName : t("subscriptionUnnamedPlan")}
+                      </p>
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        {t("subscriptionPricingLabel")}
+                      </p>
+                      <ul className="list-inside list-disc space-y-1 text-sm text-muted-foreground">
+                        {pricingLines.map((line) => (
+                          <li key={line}>{line}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  </>
+                ) : null}
+              </div>
             )}
           </div>
           {!isSuperAdmin && (

--- a/portal/src/lib/api.test.ts
+++ b/portal/src/lib/api.test.ts
@@ -3,6 +3,7 @@ import {
   login,
   register,
   getMe,
+  getCompanySubscription,
   updateTheme,
   getWaybillPdfBlobUrl,
   DESIGN_THEMES,
@@ -297,6 +298,36 @@ describe("api", () => {
       const me = await getMe("token");
 
       expect(me.theme).toBeNull();
+    });
+  });
+
+  describe("getCompanySubscription", () => {
+    it("normalizes PascalCase subscription payload", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          PlanName: "Trial",
+          PlanKind: "Trial",
+          Currency: "EUR",
+          TrialBookingAllowance: 5,
+        }),
+      });
+
+      const sub = await getCompanySubscription("token");
+
+      expect(sub.planName).toBe("Trial");
+      expect(sub.planKind).toBe("Trial");
+      expect(sub.currency).toBe("EUR");
+      expect(sub.trialBookingAllowance).toBe(5);
+    });
+
+    it("throws subscription_not_found on 404", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+
+      await expect(getCompanySubscription("token")).rejects.toThrow("subscription_not_found");
     });
   });
 

--- a/portal/src/lib/api.ts
+++ b/portal/src/lib/api.ts
@@ -220,6 +220,82 @@ export async function updateTheme(token: string, theme: string): Promise<void> {
   }
 }
 
+/** Company subscription for More page (GET /api/v1/portal/company/subscription). */
+export type PortalSubscriptionTierDto = {
+  ordinal: number;
+  inclusiveMaxBookingsInPeriod?: number | null;
+  chargePerBooking?: number | null;
+  monthlyFee?: number | null;
+};
+
+export type PortalCompanySubscriptionDto = {
+  planName: string;
+  planKind: string;
+  currency: string;
+  trialBookingAllowance?: number | null;
+  chargePerBooking?: number | null;
+  monthlyFee?: number | null;
+  includedBookingsPerMonth?: number | null;
+  overageChargePerBooking?: number | null;
+  tiers?: PortalSubscriptionTierDto[] | null;
+};
+
+function normalizePortalCompanySubscription(data: Record<string, unknown>): PortalCompanySubscriptionDto {
+  const tiersRaw = data.tiers ?? data.Tiers;
+  const tiers = Array.isArray(tiersRaw)
+    ? tiersRaw.map((row) => {
+        const t = row as Record<string, unknown>;
+        return {
+          ordinal: Number(t.ordinal ?? t.Ordinal ?? 0),
+          inclusiveMaxBookingsInPeriod:
+            t.inclusiveMaxBookingsInPeriod != null || t.InclusiveMaxBookingsInPeriod != null
+              ? Number(t.inclusiveMaxBookingsInPeriod ?? t.InclusiveMaxBookingsInPeriod)
+              : null,
+          chargePerBooking:
+            t.chargePerBooking != null || t.ChargePerBooking != null
+              ? Number(t.chargePerBooking ?? t.ChargePerBooking)
+              : null,
+          monthlyFee:
+            t.monthlyFee != null || t.MonthlyFee != null ? Number(t.monthlyFee ?? t.MonthlyFee) : null,
+        };
+      })
+    : null;
+  return {
+    planName: String(data.planName ?? data.PlanName ?? ''),
+    planKind: String(data.planKind ?? data.PlanKind ?? ''),
+    currency: String(data.currency ?? data.Currency ?? 'EUR'),
+    trialBookingAllowance:
+      data.trialBookingAllowance != null || data.TrialBookingAllowance != null
+        ? Number(data.trialBookingAllowance ?? data.TrialBookingAllowance)
+        : null,
+    chargePerBooking:
+      data.chargePerBooking != null || data.ChargePerBooking != null
+        ? Number(data.chargePerBooking ?? data.ChargePerBooking)
+        : null,
+    monthlyFee:
+      data.monthlyFee != null || data.MonthlyFee != null ? Number(data.monthlyFee ?? data.MonthlyFee) : null,
+    includedBookingsPerMonth:
+      data.includedBookingsPerMonth != null || data.IncludedBookingsPerMonth != null
+        ? Number(data.includedBookingsPerMonth ?? data.IncludedBookingsPerMonth)
+        : null,
+    overageChargePerBooking:
+      data.overageChargePerBooking != null || data.OverageChargePerBooking != null
+        ? Number(data.overageChargePerBooking ?? data.OverageChargePerBooking)
+        : null,
+    tiers,
+  };
+}
+
+export async function getCompanySubscription(token: string): Promise<PortalCompanySubscriptionDto> {
+  const res = await fetch(`${portalBase()}/company/subscription`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (res.status === 404) throw new Error('subscription_not_found');
+  if (!res.ok) throw new Error('Failed to load subscription');
+  const data = (await res.json()) as Record<string, unknown>;
+  return normalizePortalCompanySubscription(data);
+}
+
 /** Enabled courier IDs for the booking form (GET /api/v1/portal/couriers). */
 export async function getCouriers(token: string): Promise<string[]> {
   const res = await fetch(`${portalBase()}/couriers`, {

--- a/portal/src/lib/subscription-pricing.test.ts
+++ b/portal/src/lib/subscription-pricing.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildSubscriptionPricingLines } from '@/lib/subscription-pricing';
+import type { PortalCompanySubscriptionDto } from '@/lib/api';
+
+function t(key: string, _values?: Record<string, string | number>) {
+  return key;
+}
+
+describe('buildSubscriptionPricingLines', () => {
+  it('returns trial line with count', () => {
+    const sub: PortalCompanySubscriptionDto = {
+      planName: 'Trial',
+      planKind: 'Trial',
+      currency: 'EUR',
+      trialBookingAllowance: 5,
+    };
+    const spy = vi.fn(t);
+    const lines = buildSubscriptionPricingLines(sub, spy);
+    expect(lines).toHaveLength(1);
+    expect(spy).toHaveBeenCalledWith('subscriptionTrialBookings', { count: 5 });
+  });
+
+  it('returns per-booking line for PayPerBooking', () => {
+    const sub: PortalCompanySubscriptionDto = {
+      planName: 'Paygo',
+      planKind: 'PayPerBooking',
+      currency: 'EUR',
+      chargePerBooking: 9.99,
+    };
+    const lines = buildSubscriptionPricingLines(sub, t);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain('subscriptionPerBooking');
+  });
+});

--- a/portal/src/lib/subscription-pricing.ts
+++ b/portal/src/lib/subscription-pricing.ts
@@ -1,0 +1,70 @@
+import type { PortalCompanySubscriptionDto } from '@/lib/api';
+
+function formatMoney(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(amount);
+  } catch {
+    return `${amount} ${currency}`;
+  }
+}
+
+/**
+ * Human-readable pricing lines for the More page (copy uses next-intl keys under `more.*`).
+ */
+export function buildSubscriptionPricingLines(
+  sub: PortalCompanySubscriptionDto,
+  t: (key: string, values?: Record<string, string | number>) => string,
+): string[] {
+  const c = sub.currency || 'EUR';
+  const fmt = (n: number) => formatMoney(n, c);
+
+  switch (sub.planKind) {
+    case 'None':
+      return [t('subscriptionNonePlan')];
+    case 'Unknown':
+      return [t('subscriptionUnknownPlan')];
+    case 'Trial': {
+      const n = sub.trialBookingAllowance;
+      return [n != null ? t('subscriptionTrialBookings', { count: n }) : t('subscriptionTrial')];
+    }
+    case 'PayPerBooking':
+      return sub.chargePerBooking != null
+        ? [t('subscriptionPerBooking', { amount: fmt(sub.chargePerBooking) })]
+        : [t('subscriptionRatesPending')];
+    case 'MonthlyBundle': {
+      const bits: string[] = [];
+      if (sub.monthlyFee != null) bits.push(t('subscriptionMonthlyBase', { amount: fmt(sub.monthlyFee) }));
+      if (sub.includedBookingsPerMonth != null)
+        bits.push(t('subscriptionIncludedBookings', { count: sub.includedBookingsPerMonth }));
+      if (sub.overageChargePerBooking != null && sub.includedBookingsPerMonth != null)
+        bits.push(t('subscriptionOverageEach', { amount: fmt(sub.overageChargePerBooking) }));
+      return bits.length > 0 ? bits : [t('subscriptionRatesPending')];
+    }
+    case 'TieredPayPerBooking':
+      if (sub.tiers?.length) {
+        return sub.tiers.map((tier) => {
+          const max = tier.inclusiveMaxBookingsInPeriod;
+          const band =
+            max != null ? t('subscriptionTierBandMax', { max }) : t('subscriptionTierBandOpen');
+          if (tier.chargePerBooking != null)
+            return `${band}: ${fmt(tier.chargePerBooking)} ${t('subscriptionPerBookingShort')}`;
+          return band;
+        });
+      }
+      return [t('subscriptionRatesPending')];
+    case 'TieredMonthlyByUsage':
+      if (sub.tiers?.length) {
+        return sub.tiers.map((tier) => {
+          const max = tier.inclusiveMaxBookingsInPeriod;
+          const band =
+            max != null ? t('subscriptionTierBandMax', { max }) : t('subscriptionTierBandOpen');
+          if (tier.monthlyFee != null)
+            return `${band}: ${fmt(tier.monthlyFee)} ${t('subscriptionPerMonthShort')}`;
+          return band;
+        });
+      }
+      return [t('subscriptionRatesPending')];
+    default:
+      return [t('subscriptionRatesPending')];
+  }
+}


### PR DESCRIPTION
Adds \GET /api/v1/portal/company/subscription\ returning the company's plan, currency, active pricing period fields, and tier bands. The portal **More** page shows plan name and a concise pricing summary (with i18n).

Includes \PortalCompanySubscriptionReader\ plus integration tests so backend line/branch coverage stays above the 75% CI gate.

**Verify:** \dotnet test\ with coverlet, \cd portal && npm run test:coverage\.