### PR TITLE
feat(admin): default trial for legacy companies, subscription PATCH validation

### DIFF
--- a/CargoHub.Api/Program.cs
+++ b/CargoHub.Api/Program.cs
@@ -287,6 +287,7 @@ using (var scope = app.Services.CreateScope())
     db.EnsureCriticalSchema();
 
     SubscriptionPlanSeed.EnsureDefaultTrialPlanAsync(db).GetAwaiter().GetResult();
+    SubscriptionPlanSeed.AssignDefaultTrialToCompaniesWithoutPlanAsync(db).GetAwaiter().GetResult();
 
     var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
     foreach (var roleName in new[] { CargoHub.Application.Auth.RoleNames.SuperAdmin, CargoHub.Application.Auth.RoleNames.Admin, CargoHub.Application.Auth.RoleNames.User })

--- a/CargoHub.Application/AdminCompanies/UpdateAdminCompanyCommandHandler.cs
+++ b/CargoHub.Application/AdminCompanies/UpdateAdminCompanyCommandHandler.cs
@@ -1,3 +1,4 @@
+using CargoHub.Application.Billing.AdminPlans;
 using CargoHub.Application.Company;
 using MediatR;
 
@@ -9,17 +10,20 @@ public sealed class UpdateAdminCompanyCommandHandler : IRequestHandler<UpdateAdm
     private readonly ICompanyAdminInviteIssuer _inviteIssuer;
     private readonly ICompanyUserMetrics _metrics;
     private readonly IAdminCompanyLimitUserOperations _limitUserOperations;
+    private readonly ISubscriptionPlanAdminRepository _subscriptionPlans;
 
     public UpdateAdminCompanyCommandHandler(
         ICompanyRepository companies,
         ICompanyAdminInviteIssuer inviteIssuer,
         ICompanyUserMetrics metrics,
-        IAdminCompanyLimitUserOperations limitUserOperations)
+        IAdminCompanyLimitUserOperations limitUserOperations,
+        ISubscriptionPlanAdminRepository subscriptionPlans)
     {
         _companies = companies;
         _inviteIssuer = inviteIssuer;
         _metrics = metrics;
         _limitUserOperations = limitUserOperations;
+        _subscriptionPlans = subscriptionPlans;
     }
 
     public async Task<AdminCompanyMutationResult> Handle(UpdateAdminCompanyCommand request, CancellationToken cancellationToken)
@@ -28,6 +32,14 @@ public sealed class UpdateAdminCompanyCommandHandler : IRequestHandler<UpdateAdm
             return Fail("InvalidMaxUsers", "Max user accounts must be at least 1 when set.");
         if (request.MaxAdminAccounts is < 1)
             return Fail("InvalidMaxAdmins", "Max admin accounts must be at least 1 when set.");
+
+        if (request.SubscriptionPlanId is { } planId)
+        {
+            if (planId == Guid.Empty)
+                return Fail("InvalidSubscriptionPlan", "Subscription plan id is invalid.");
+            if (!await _subscriptionPlans.PlanExistsAsync(planId, cancellationToken))
+                return Fail("SubscriptionPlanNotFound", "Subscription plan was not found.");
+        }
 
         var company = await _companies.GetByIdForUpdateAsync(request.CompanyId, cancellationToken);
         if (company == null)

--- a/CargoHub.Infrastructure/Billing/SubscriptionPlanSeed.cs
+++ b/CargoHub.Infrastructure/Billing/SubscriptionPlanSeed.cs
@@ -33,4 +33,22 @@ public static class SubscriptionPlanSeed
 
         await db.SaveChangesAsync(cancellationToken);
     }
+
+    /// <summary>
+    /// Companies created before billing used a null plan; assign the seeded default Trial plan so billing and admin UI behave consistently.
+    /// </summary>
+    public static async Task AssignDefaultTrialToCompaniesWithoutPlanAsync(
+        ApplicationDbContext db,
+        CancellationToken cancellationToken = default)
+    {
+        var trialId = SubscriptionBillingConstants.DefaultTrialPlanId;
+        var rows = await db.Companies
+            .Where(c => c.SubscriptionPlanId == null)
+            .ToListAsync(cancellationToken);
+        if (rows.Count == 0)
+            return;
+        foreach (var c in rows)
+            c.SubscriptionPlanId = trialId;
+        await db.SaveChangesAsync(cancellationToken);
+    }
 }

--- a/CargoHub.Tests/AdminCompanies/UpdateAdminCompanyCommandHandlerTests.cs
+++ b/CargoHub.Tests/AdminCompanies/UpdateAdminCompanyCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using CargoHub.Application.AdminCompanies;
+using CargoHub.Application.Billing.AdminPlans;
 using CargoHub.Application.Company;
 using Moq;
 using Xunit;
@@ -12,13 +13,23 @@ public class UpdateAdminCompanyCommandHandlerTests
         out Mock<ICompanyRepository> repo,
         out Mock<ICompanyAdminInviteIssuer> invites,
         out Mock<ICompanyUserMetrics> metrics,
-        out Mock<IAdminCompanyLimitUserOperations> limits)
+        out Mock<IAdminCompanyLimitUserOperations> limits,
+        out Mock<ISubscriptionPlanAdminRepository> planRepo)
     {
         repo = new Mock<ICompanyRepository>();
         invites = new Mock<ICompanyAdminInviteIssuer>();
         metrics = new Mock<ICompanyUserMetrics>();
         limits = new Mock<IAdminCompanyLimitUserOperations>();
-        return new UpdateAdminCompanyCommandHandler(repo.Object, invites.Object, metrics.Object, limits.Object);
+        planRepo = new Mock<ISubscriptionPlanAdminRepository>();
+        planRepo
+            .Setup(x => x.PlanExistsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        return new UpdateAdminCompanyCommandHandler(
+            repo.Object,
+            invites.Object,
+            metrics.Object,
+            limits.Object,
+            planRepo.Object);
     }
 
     private static CompanyEntity TrackedCompany(Guid id, string bid = "BIZ-1") => new()
@@ -34,7 +45,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     [Fact]
     public async Task Handle_MaxUsersBelowOne_Fails()
     {
-        var h = CreateHandler(out _, out _, out _, out _);
+        var h = CreateHandler(out _, out _, out _, out _, out _);
         var r = await h.Handle(new UpdateAdminCompanyCommand(Guid.NewGuid(), 0, null, false, null, null), default);
         Assert.False(r.Success);
         Assert.Equal("InvalidMaxUsers", r.ErrorCode);
@@ -43,7 +54,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     [Fact]
     public async Task Handle_MaxAdminsBelowOne_Fails()
     {
-        var h = CreateHandler(out _, out _, out _, out _);
+        var h = CreateHandler(out _, out _, out _, out _, out _);
         var r = await h.Handle(new UpdateAdminCompanyCommand(Guid.NewGuid(), null, 0, false, null, null), default);
         Assert.False(r.Success);
         Assert.Equal("InvalidMaxAdmins", r.ErrorCode);
@@ -52,7 +63,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     [Fact]
     public async Task Handle_CompanyNotFound_Fails()
     {
-        var h = CreateHandler(out var repo, out _, out _, out _);
+        var h = CreateHandler(out var repo, out _, out _, out _, out _);
         var id = Guid.NewGuid();
         repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync((CompanyEntity?)null);
 
@@ -65,7 +76,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     public async Task Handle_LimitReduction_NeedsMoreDemotions_ReturnsConflict()
     {
         var id = Guid.NewGuid();
-        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _, out _);
         repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(TrackedCompany(id));
         metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(3);
         metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(4);
@@ -82,7 +93,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     public async Task Handle_LimitReduction_NeedsMoreDeactivations_ReturnsConflict()
     {
         var id = Guid.NewGuid();
-        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _, out _);
         repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(TrackedCompany(id));
         metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(12);
         metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
@@ -98,7 +109,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     public async Task Handle_UnexpectedDemotions_Fails()
     {
         var id = Guid.NewGuid();
-        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _, out _);
         repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(TrackedCompany(id));
         metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
         metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
@@ -115,7 +126,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     public async Task Handle_UnexpectedDeactivations_Fails()
     {
         var id = Guid.NewGuid();
-        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _, out _);
         repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(TrackedCompany(id));
         metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
         metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
@@ -132,7 +143,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     public async Task Handle_DemoteFails_ReturnsError()
     {
         var id = Guid.NewGuid();
-        var h = CreateHandler(out var repo, out _, out var metrics, out var limits);
+        var h = CreateHandler(out var repo, out _, out var metrics, out var limits, out _);
         repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(TrackedCompany(id));
         metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
         metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(4);
@@ -152,7 +163,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     public async Task Handle_DeactivateFails_ReturnsError()
     {
         var id = Guid.NewGuid();
-        var h = CreateHandler(out var repo, out _, out var metrics, out var limits);
+        var h = CreateHandler(out var repo, out _, out var metrics, out var limits, out _);
         repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(TrackedCompany(id));
         metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(12);
         metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
@@ -173,7 +184,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     {
         var id = Guid.NewGuid();
         var company = TrackedCompany(id);
-        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _, out _);
         repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
         metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
         metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
@@ -192,7 +203,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     {
         var id = Guid.NewGuid();
         var company = TrackedCompany(id, "");
-        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _, out _);
         repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
         metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("", default)).ReturnsAsync(0);
         metrics.Setup(x => x.CountAdminsForBusinessIdAsync("", default)).ReturnsAsync(0);
@@ -209,7 +220,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     {
         var id = Guid.NewGuid();
         var company = TrackedCompany(id);
-        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _, out _);
         repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
         metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
         metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
@@ -227,7 +238,7 @@ public class UpdateAdminCompanyCommandHandlerTests
         var id = Guid.NewGuid();
         var company = TrackedCompany(id);
         company.InitialAdminInviteEmail = "a@test.com";
-        var h = CreateHandler(out var repo, out var invites, out var metrics, out _);
+        var h = CreateHandler(out var repo, out var invites, out var metrics, out _, out _);
         repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
         metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
         metrics.SetupSequence(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default))
@@ -251,7 +262,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     {
         var id = Guid.NewGuid();
         var company = TrackedCompany(id);
-        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _, out _);
         repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
         metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
         metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
@@ -269,7 +280,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     {
         var id = Guid.NewGuid();
         var company = TrackedCompany(id, "");
-        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _, out _);
         repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
         repo.Setup(x => x.UpdateAsync(company, default)).ReturnsAsync(company);
         repo.Setup(x => x.GetByIdAsync(id, default)).ReturnsAsync(company);
@@ -285,7 +296,7 @@ public class UpdateAdminCompanyCommandHandlerTests
     {
         var id = Guid.NewGuid();
         var company = TrackedCompany(id);
-        var h = CreateHandler(out var repo, out _, out var metrics, out _);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _, out _);
         repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
         metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
         metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
@@ -296,5 +307,37 @@ public class UpdateAdminCompanyCommandHandlerTests
         Assert.True(r.Success);
         Assert.Equal(newPlan, company.SubscriptionPlanId);
         Assert.Equal(newPlan, r.Company!.SubscriptionPlanId);
+    }
+
+    [Fact]
+    public async Task Handle_UnknownSubscriptionPlanId_Fails()
+    {
+        var id = Guid.NewGuid();
+        var company = TrackedCompany(id);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _, out var planRepo);
+        planRepo.Setup(x => x.PlanExistsAsync(It.IsAny<Guid>(), default)).ReturnsAsync(false);
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
+        metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        var badPlan = Guid.NewGuid();
+        var r = await h.Handle(new UpdateAdminCompanyCommand(id, null, null, false, null, null, badPlan), default);
+        Assert.False(r.Success);
+        Assert.Equal("SubscriptionPlanNotFound", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyGuidSubscriptionPlan_Fails()
+    {
+        var id = Guid.NewGuid();
+        var company = TrackedCompany(id);
+        var h = CreateHandler(out var repo, out _, out var metrics, out _, out _);
+        repo.Setup(x => x.GetByIdForUpdateAsync(id, default)).ReturnsAsync(company);
+        metrics.Setup(x => x.CountActiveUsersForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        metrics.Setup(x => x.CountAdminsForBusinessIdAsync("BIZ-1", default)).ReturnsAsync(1);
+        var r = await h.Handle(
+            new UpdateAdminCompanyCommand(id, null, null, false, null, null, Guid.Empty),
+            default);
+        Assert.False(r.Success);
+        Assert.Equal("InvalidSubscriptionPlan", r.ErrorCode);
     }
 }

--- a/CargoHub.Tests/Billing/AdminBillingInvoiceOperationsTests.cs
+++ b/CargoHub.Tests/Billing/AdminBillingInvoiceOperationsTests.cs
@@ -1,0 +1,386 @@
+using CargoHub.Application.Auth;
+using CargoHub.Application.Billing.Admin;
+using CargoHub.Application.Billing.AdminInvoicing;
+using CargoHub.Application.Couriers;
+using CargoHub.Domain.Billing;
+using CargoHub.Infrastructure.Billing;
+using CargoHub.Infrastructure.Identity;
+using CargoHub.Infrastructure.Persistence;
+using CompanyEntity = CargoHub.Domain.Companies.Company;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace CargoHub.Tests.Billing;
+
+public sealed class AdminBillingInvoiceOperationsTests
+{
+    private static ServiceProvider CreateServiceProvider(out string dbName)
+    {
+        var name = Guid.NewGuid().ToString("N");
+        dbName = name;
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<ApplicationDbContext>(o => o.UseInMemoryDatabase(name));
+        services
+            .AddIdentity<ApplicationUser, IdentityRole>(o =>
+            {
+                o.Password.RequireDigit = true;
+                o.Password.RequireLowercase = true;
+                o.Password.RequireUppercase = false;
+                o.Password.RequireNonAlphanumeric = false;
+                o.Password.RequiredLength = 6;
+            })
+            .AddEntityFrameworkStores<ApplicationDbContext>()
+            .AddDefaultTokenProviders();
+        var sp = services.BuildServiceProvider();
+        using var scope = sp.CreateScope();
+        scope.ServiceProvider.GetRequiredService<ApplicationDbContext>().Database.EnsureCreated();
+        return sp;
+    }
+
+    private static async Task EnsureRolesAsync(RoleManager<IdentityRole> roles)
+    {
+        foreach (var name in new[] { RoleNames.SuperAdmin, RoleNames.Admin, RoleNames.User })
+        {
+            if (!await roles.RoleExistsAsync(name))
+                await roles.CreateAsync(new IdentityRole(name));
+        }
+    }
+
+    private static AdminBillingInvoiceOperations CreateOps(
+        ApplicationDbContext db,
+        UserManager<ApplicationUser> users,
+        IAdminBillingReader reader,
+        IEmailSender email,
+        IBillingInvoicePdfGenerator pdf) =>
+        new(db, users, reader, email, pdf);
+
+    [Fact]
+    public async Task SendInvoiceEmailAsync_recipient_empty_fails()
+    {
+        using var sp = CreateServiceProvider(out _);
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var mockR = new Mock<IAdminBillingReader>();
+        var mockE = new Mock<IEmailSender>();
+        var mockP = new Mock<IBillingInvoicePdfGenerator>();
+        var ops = CreateOps(db, users, mockR.Object, mockE.Object, mockP.Object);
+
+        var r = await ops.SendInvoiceEmailAsync(Guid.NewGuid(), "  ", "sa");
+        Assert.False(r.Success);
+        Assert.Equal("RecipientRequired", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task SendInvoiceEmailAsync_period_not_found_fails()
+    {
+        using var sp = CreateServiceProvider(out _);
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var mockR = new Mock<IAdminBillingReader>();
+        mockR.Setup(x => x.GetInvoicePdfModelAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BillingInvoicePdfModel?)null);
+        var ops = CreateOps(db, users, mockR.Object, Mock.Of<IEmailSender>(), Mock.Of<IBillingInvoicePdfGenerator>());
+
+        var r = await ops.SendInvoiceEmailAsync(Guid.NewGuid(), "user1", "sa");
+        Assert.False(r.Success);
+        Assert.Equal("NotFound", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task SendInvoiceEmailAsync_company_row_missing_fails()
+    {
+        using var sp = CreateServiceProvider(out _);
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var companyId = Guid.NewGuid();
+        var mockR = new Mock<IAdminBillingReader>();
+        mockR.Setup(x => x.GetInvoicePdfModelAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingInvoicePdfModel
+            {
+                PeriodId = Guid.NewGuid(),
+                CompanyId = companyId,
+                CompanyName = "X",
+                YearUtc = 2026,
+                MonthUtc = 4,
+                Currency = "EUR",
+                Status = "Open",
+                PayableTotal = 1m,
+                LedgerTotal = 1m,
+                Lines = Array.Empty<BillingInvoicePdfLineModel>()
+            });
+        var ops = CreateOps(db, users, mockR.Object, Mock.Of<IEmailSender>(), Mock.Of<IBillingInvoicePdfGenerator>());
+
+        var r = await ops.SendInvoiceEmailAsync(Guid.NewGuid(), "u1", "sa");
+        Assert.False(r.Success);
+        Assert.Equal("CompanyNotFound", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task SendInvoiceEmailAsync_user_validation_failures()
+    {
+        using var sp = CreateServiceProvider(out _);
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var roles = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+        await EnsureRolesAsync(roles);
+
+        var companyId = Guid.NewGuid();
+        db.Companies.Add(new CompanyEntity { Id = companyId, CompanyId = Guid.NewGuid().ToString("N"), BusinessId = "BIZ-1" });
+        await db.SaveChangesAsync();
+
+        var periodId = Guid.NewGuid();
+        var mockR = new Mock<IAdminBillingReader>();
+        mockR.Setup(x => x.GetInvoicePdfModelAsync(periodId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingInvoicePdfModel
+            {
+                PeriodId = periodId,
+                CompanyId = companyId,
+                CompanyName = "Co",
+                YearUtc = 2026,
+                MonthUtc = 4,
+                Currency = "EUR",
+                Status = "Open",
+                PayableTotal = 1m,
+                LedgerTotal = 2m,
+                Lines = Array.Empty<BillingInvoicePdfLineModel>()
+            });
+
+        var mockE = new Mock<IEmailSender>();
+        var mockP = new Mock<IBillingInvoicePdfGenerator>();
+        var ops = CreateOps(db, users, mockR.Object, mockE.Object, mockP.Object);
+
+        var rUnknown = await ops.SendInvoiceEmailAsync(periodId, Guid.NewGuid().ToString(), "sa");
+        Assert.Equal("RecipientNotFound", rUnknown.ErrorCode);
+
+        var uInactive = new ApplicationUser
+        {
+            UserName = "a1@test.com",
+            Email = "a1@test.com",
+            EmailConfirmed = true,
+            IsActive = false,
+            BusinessId = "BIZ-1"
+        };
+        await users.CreateAsync(uInactive, "Test1!x");
+        await users.AddToRoleAsync(uInactive, RoleNames.Admin);
+        var rInactive = await ops.SendInvoiceEmailAsync(periodId, uInactive.Id, "sa");
+        Assert.Equal("RecipientInactive", rInactive.ErrorCode);
+
+        var uUserRole = new ApplicationUser
+        {
+            UserName = "a2@test.com",
+            Email = "a2@test.com",
+            EmailConfirmed = true,
+            IsActive = true,
+            BusinessId = "BIZ-1"
+        };
+        await users.CreateAsync(uUserRole, "Test1!x");
+        await users.AddToRoleAsync(uUserRole, RoleNames.User);
+        var rNotAdmin = await ops.SendInvoiceEmailAsync(periodId, uUserRole.Id, "sa");
+        Assert.Equal("RecipientNotAdmin", rNotAdmin.ErrorCode);
+
+        var uNoBiz = new ApplicationUser
+        {
+            UserName = "a3@test.com",
+            Email = "a3@test.com",
+            EmailConfirmed = true,
+            IsActive = true,
+            BusinessId = null
+        };
+        await users.CreateAsync(uNoBiz, "Test1!x");
+        await users.AddToRoleAsync(uNoBiz, RoleNames.Admin);
+        var rNoBiz = await ops.SendInvoiceEmailAsync(periodId, uNoBiz.Id, "sa");
+        Assert.Equal("BusinessIdMismatch", rNoBiz.ErrorCode);
+
+        db.Companies.Remove(db.Companies.First(c => c.Id == companyId));
+        db.Companies.Add(new CompanyEntity { Id = companyId, CompanyId = "c2", BusinessId = null });
+        await db.SaveChangesAsync();
+        var uOkBiz = new ApplicationUser
+        {
+            UserName = "a4@test.com",
+            Email = "a4@test.com",
+            EmailConfirmed = true,
+            IsActive = true,
+            BusinessId = "BIZ-1"
+        };
+        await users.CreateAsync(uOkBiz, "Test1!x");
+        await users.AddToRoleAsync(uOkBiz, RoleNames.Admin);
+        var rCoNoBiz = await ops.SendInvoiceEmailAsync(periodId, uOkBiz.Id, "sa");
+        Assert.Equal("BusinessIdMismatch", rCoNoBiz.ErrorCode);
+
+        db.Companies.Remove(db.Companies.First(c => c.Id == companyId));
+        db.Companies.Add(new CompanyEntity { Id = companyId, CompanyId = "c3", BusinessId = "BIZ-1" });
+        await db.SaveChangesAsync();
+
+        var uWrong = new ApplicationUser
+        {
+            UserName = "a5@test.com",
+            Email = "a5@test.com",
+            EmailConfirmed = true,
+            IsActive = true,
+            BusinessId = "OTHER"
+        };
+        await users.CreateAsync(uWrong, "Test1!x");
+        await users.AddToRoleAsync(uWrong, RoleNames.Admin);
+        var rWrong = await ops.SendInvoiceEmailAsync(periodId, uWrong.Id, "sa");
+        Assert.Equal("RecipientWrongCompany", rWrong.ErrorCode);
+
+        var uNoEmail = new ApplicationUser
+        {
+            UserName = "a6@test.com",
+            Email = null,
+            EmailConfirmed = true,
+            IsActive = true,
+            BusinessId = "BIZ-1"
+        };
+        await users.CreateAsync(uNoEmail, "Test1!x");
+        await users.AddToRoleAsync(uNoEmail, RoleNames.Admin);
+        var rNoEmail = await ops.SendInvoiceEmailAsync(periodId, uNoEmail.Id, "sa");
+        Assert.Equal("RecipientNoEmail", rNoEmail.ErrorCode);
+    }
+
+    [Fact]
+    public async Task SendInvoiceEmailAsync_success_sends_and_persists_audit()
+    {
+        using var sp = CreateServiceProvider(out _);
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var roles = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+        await EnsureRolesAsync(roles);
+
+        var companyId = Guid.NewGuid();
+        db.Companies.Add(new CompanyEntity { Id = companyId, CompanyId = Guid.NewGuid().ToString("N"), BusinessId = "BIZ-OK" });
+        await db.SaveChangesAsync();
+
+        var periodId = Guid.NewGuid();
+        var mockR = new Mock<IAdminBillingReader>();
+        mockR.Setup(x => x.GetInvoicePdfModelAsync(periodId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BillingInvoicePdfModel
+            {
+                PeriodId = periodId,
+                CompanyId = companyId,
+                CompanyName = "Acme",
+                YearUtc = 2026,
+                MonthUtc = 5,
+                Currency = "EUR",
+                Status = "Open",
+                PayableTotal = 10m,
+                LedgerTotal = 12m,
+                Lines = Array.Empty<BillingInvoicePdfLineModel>()
+            });
+
+        var mockE = new Mock<IEmailSender>();
+        var mockP = new Mock<IBillingInvoicePdfGenerator>();
+        mockP.Setup(x => x.GeneratePdf(It.IsAny<BillingInvoicePdfModel>())).Returns(new byte[] { 9, 9 });
+
+        var admin = new ApplicationUser
+        {
+            UserName = "adminok@test.com",
+            Email = "adminok@test.com",
+            EmailConfirmed = true,
+            IsActive = true,
+            BusinessId = "BIZ-OK"
+        };
+        await users.CreateAsync(admin, "Test1!x");
+        await users.AddToRoleAsync(admin, RoleNames.Admin);
+
+        var ops = CreateOps(db, users, mockR.Object, mockE.Object, mockP.Object);
+        var r = await ops.SendInvoiceEmailAsync(periodId, admin.Id, "super-admin-id");
+        Assert.True(r.Success);
+
+        mockE.Verify(
+            x => x.SendAsync(
+                "adminok@test.com",
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.Is<IReadOnlyList<EmailAttachment>>(a => a.Count == 1 && a[0].Content.Length == 2),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        Assert.Equal(1, await db.SubscriptionInvoiceSends.CountAsync(s => s.CompanyBillingPeriodId == periodId));
+    }
+
+    [Fact]
+    public async Task UpdateLineExcludedAsync_not_found()
+    {
+        using var sp = CreateServiceProvider(out _);
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+        var ops = CreateOps(db, users, Mock.Of<IAdminBillingReader>(), Mock.Of<IEmailSender>(), Mock.Of<IBillingInvoicePdfGenerator>());
+
+        var r = await ops.UpdateLineExcludedAsync(Guid.NewGuid(), true, "sa");
+        Assert.False(r.Success);
+        Assert.Equal("NotFound", r.ErrorCode);
+    }
+
+    [Fact]
+    public async Task UpdateLineExcludedAsync_updates_row()
+    {
+        using var sp = CreateServiceProvider(out _);
+        using var scope = sp.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var users = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+        var planId = Guid.NewGuid();
+        var periodPricingId = Guid.NewGuid();
+        var companyId = Guid.NewGuid();
+        db.SubscriptionPlans.Add(new SubscriptionPlan
+        {
+            Id = planId,
+            Name = "P",
+            Kind = SubscriptionPlanKind.PayPerBooking,
+            ChargeTimeAnchor = ChargeTimeAnchor.CreatedAtUtc,
+            Currency = "EUR",
+            IsActive = true
+        });
+        db.SubscriptionPlanPricingPeriods.Add(new SubscriptionPlanPricingPeriod
+        {
+            Id = periodPricingId,
+            SubscriptionPlanId = planId,
+            EffectiveFromUtc = DateTime.UtcNow
+        });
+        db.Companies.Add(new CompanyEntity { Id = companyId, CompanyId = Guid.NewGuid().ToString("N") });
+        var billingPeriodId = Guid.NewGuid();
+        db.CompanyBillingPeriods.Add(new CompanyBillingPeriod
+        {
+            Id = billingPeriodId,
+            CompanyId = companyId,
+            YearUtc = 2026,
+            MonthUtc = 6,
+            Currency = "EUR",
+            Status = CompanyBillingPeriodStatus.Open
+        });
+        var lineId = Guid.NewGuid();
+        db.BillingLineItems.Add(new BillingLineItem
+        {
+            Id = lineId,
+            CompanyBillingPeriodId = billingPeriodId,
+            LineType = BillingLineType.Adjustment,
+            Amount = 3m,
+            Currency = "EUR",
+            SubscriptionPlanId = planId,
+            SubscriptionPlanPricingPeriodId = periodPricingId,
+            CreatedAtUtc = DateTime.UtcNow,
+            ExcludedFromInvoice = false
+        });
+        await db.SaveChangesAsync();
+
+        var ops = CreateOps(db, users, Mock.Of<IAdminBillingReader>(), Mock.Of<IEmailSender>(), Mock.Of<IBillingInvoicePdfGenerator>());
+        var r = await ops.UpdateLineExcludedAsync(lineId, true, "super-admin");
+        Assert.True(r.Success);
+
+        var line = await db.BillingLineItems.FirstAsync(l => l.Id == lineId);
+        Assert.True(line.ExcludedFromInvoice);
+        Assert.Equal("super-admin", line.InvoiceExclusionUpdatedByUserId);
+        Assert.NotNull(line.InvoiceExclusionUpdatedAtUtc);
+    }
+}

--- a/CargoHub.Tests/Billing/AdminBillingMediatRHandlersTests.cs
+++ b/CargoHub.Tests/Billing/AdminBillingMediatRHandlersTests.cs
@@ -1,0 +1,144 @@
+using CargoHub.Application.Billing.Admin;
+using CargoHub.Application.Billing.AdminInvoicing;
+using CargoHub.Application.Billing.AdminPlans;
+using Moq;
+using Xunit;
+
+namespace CargoHub.Tests.Billing;
+
+public sealed class AdminBillingMediatRHandlersTests
+{
+    [Fact]
+    public async Task GetBillingPeriodDetailQueryHandler_delegates()
+    {
+        var mock = new Mock<IAdminBillingReader>();
+        mock.Setup(x => x.GetBillingPeriodDetailAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BillingPeriodDetailDto?)null);
+        var h = new GetBillingPeriodDetailQueryHandler(mock.Object);
+        await h.Handle(new GetBillingPeriodDetailQuery(Guid.NewGuid()), default);
+        mock.Verify(x => x.GetBillingPeriodDetailAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ListAdminSubscriptionPlansQueryHandler_delegates()
+    {
+        var mock = new Mock<IAdminBillingReader>();
+        mock.Setup(x => x.ListSubscriptionPlansAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AdminSubscriptionPlanSummaryDto>());
+        var h = new ListAdminSubscriptionPlansQueryHandler(mock.Object);
+        await h.Handle(new ListAdminSubscriptionPlansQuery(), default);
+        mock.Verify(x => x.ListSubscriptionPlansAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ListCompanyBillingPeriodsQueryHandler_delegates()
+    {
+        var mock = new Mock<IAdminBillingReader>();
+        mock.Setup(x => x.ListBillingPeriodsForCompanyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<CompanyBillingPeriodSummaryDto>());
+        var h = new ListCompanyBillingPeriodsQueryHandler(mock.Object);
+        await h.Handle(new ListCompanyBillingPeriodsQuery(Guid.NewGuid()), default);
+        mock.Verify(x => x.ListBillingPeriodsForCompanyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetBillingInvoicePdfModelQueryHandler_delegates()
+    {
+        var mock = new Mock<IAdminBillingReader>();
+        mock.Setup(x => x.GetInvoicePdfModelAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BillingInvoicePdfModel?)null);
+        var h = new GetBillingInvoicePdfModelQueryHandler(mock.Object);
+        await h.Handle(new GetBillingInvoicePdfModelQuery(Guid.NewGuid()), default);
+        mock.Verify(x => x.GetInvoicePdfModelAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendBillingPeriodInvoiceEmailCommandHandler_delegates()
+    {
+        var mock = new Mock<IAdminBillingInvoiceOperations>();
+        mock.Setup(x => x.SendInvoiceEmailAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SendInvoiceEmailResult.Ok());
+        var h = new SendBillingPeriodInvoiceEmailCommandHandler(mock.Object);
+        await h.Handle(new SendBillingPeriodInvoiceEmailCommand(Guid.NewGuid(), "u1", "sa"), default);
+        mock.Verify(x => x.SendInvoiceEmailAsync(It.IsAny<Guid>(), "u1", "sa", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateBillingLineExcludedCommandHandler_delegates()
+    {
+        var mock = new Mock<IAdminBillingInvoiceOperations>();
+        mock.Setup(x => x.UpdateLineExcludedAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UpdateLineExcludedResult.Ok());
+        var h = new UpdateBillingLineExcludedCommandHandler(mock.Object);
+        await h.Handle(new UpdateBillingLineExcludedCommand(Guid.NewGuid(), true, "sa"), default);
+        mock.Verify(x => x.UpdateLineExcludedAsync(It.IsAny<Guid>(), true, "sa", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAdminSubscriptionPlanDetailQueryHandler_delegates()
+    {
+        var mock = new Mock<ISubscriptionPlanAdminRepository>();
+        mock.Setup(x => x.GetPlanDetailAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AdminSubscriptionPlanDetailDto?)null);
+        var h = new GetAdminSubscriptionPlanDetailQueryHandler(mock.Object);
+        await h.Handle(new GetAdminSubscriptionPlanDetailQuery(Guid.NewGuid()), default);
+        mock.Verify(x => x.GetPlanDetailAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Plan_command_handlers_delegate_to_repository()
+    {
+        var id = Guid.NewGuid();
+        var repo = new Mock<ISubscriptionPlanAdminRepository>();
+        repo.Setup(x => x.CreatePlanAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(id);
+        repo.Setup(x => x.DeletePlanAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AdminPlanMutationResult.Ok());
+        repo.Setup(x => x.AddPricingPeriodAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<decimal?>(), It.IsAny<decimal?>(), It.IsAny<int?>(), It.IsAny<decimal?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AdminPlanMutationResult.Ok());
+        repo.Setup(x => x.UpdatePricingPeriodAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<decimal?>(), It.IsAny<decimal?>(), It.IsAny<int?>(), It.IsAny<decimal?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AdminPlanMutationResult.Ok());
+        repo.Setup(x => x.DeletePricingPeriodAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AdminPlanMutationResult.Ok());
+        repo.Setup(x => x.ReplaceTiersAsync(It.IsAny<Guid>(), It.IsAny<IReadOnlyList<AdminPricingTierInput>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AdminPlanMutationResult.Ok());
+        repo.Setup(x => x.UpdatePlanAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AdminPlanMutationResult.Ok());
+
+        await new AddAdminPricingPeriodCommandHandler(repo.Object).Handle(
+            new AddAdminPricingPeriodCommand(Guid.NewGuid(), DateTime.UtcNow, null, null, null, null), default);
+        await new UpdateAdminPricingPeriodCommandHandler(repo.Object).Handle(
+            new UpdateAdminPricingPeriodCommand(Guid.NewGuid(), DateTime.UtcNow, null, null, null, null), default);
+        await new DeleteAdminPricingPeriodCommandHandler(repo.Object).Handle(new DeleteAdminPricingPeriodCommand(Guid.NewGuid()), default);
+        await new DeleteAdminSubscriptionPlanCommandHandler(repo.Object).Handle(new DeleteAdminSubscriptionPlanCommand(Guid.NewGuid()), default);
+        await new ReplaceAdminPricingPeriodTiersCommandHandler(repo.Object).Handle(
+            new ReplaceAdminPricingPeriodTiersCommand(Guid.NewGuid(), Array.Empty<AdminPricingTierInput>()), default);
+
+        var create = await new CreateAdminSubscriptionPlanCommandHandler(repo.Object).Handle(
+            new CreateAdminSubscriptionPlanCommand("N", "PayPerBooking", "CreatedAtUtc", null, "EUR", true), default);
+        Assert.True(create.Success);
+
+        var update = await new UpdateAdminSubscriptionPlanCommandHandler(repo.Object).Handle(
+            new UpdateAdminSubscriptionPlanCommand(Guid.NewGuid(), "N", "PayPerBooking", "CreatedAtUtc", null, "EUR", true), default);
+        Assert.True(update.Success);
+    }
+
+    [Fact]
+    public async Task CreateAdminSubscriptionPlanCommandHandler_validation_branches()
+    {
+        var repo = new Mock<ISubscriptionPlanAdminRepository>();
+        var h = new CreateAdminSubscriptionPlanCommandHandler(repo.Object);
+
+        Assert.False((await h.Handle(new CreateAdminSubscriptionPlanCommand("", "PayPerBooking", "CreatedAtUtc", null, "EUR", true), default)).Success);
+        Assert.False((await h.Handle(new CreateAdminSubscriptionPlanCommand("N", "X", "CreatedAtUtc", null, "EUR", true), default)).Success);
+        Assert.False((await h.Handle(new CreateAdminSubscriptionPlanCommand("N", "PayPerBooking", "X", null, "EUR", true), default)).Success);
+        Assert.False((await h.Handle(new CreateAdminSubscriptionPlanCommand("N", "Trial", "CreatedAtUtc", null, "EUR", true), default)).Success);
+        Assert.False((await h.Handle(new CreateAdminSubscriptionPlanCommand("N", "PayPerBooking", "CreatedAtUtc", null, "EURO", true), default)).Success);
+
+        repo.Setup(x => x.CreatePlanAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("db"));
+        var fail = await h.Handle(new CreateAdminSubscriptionPlanCommand("N", "PayPerBooking", "CreatedAtUtc", null, "EUR", true), default);
+        Assert.False(fail.Success);
+        Assert.Equal("CreateFailed", fail.ErrorCode);
+    }
+}

--- a/CargoHub.Tests/Billing/SubscriptionPlanAdminRepositoryTests.cs
+++ b/CargoHub.Tests/Billing/SubscriptionPlanAdminRepositoryTests.cs
@@ -1,0 +1,357 @@
+using CargoHub.Application.Billing.AdminPlans;
+using CargoHub.Domain.Billing;
+using CargoHub.Infrastructure.Persistence;
+using CompanyEntity = CargoHub.Domain.Companies.Company;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace CargoHub.Tests.Billing;
+
+public sealed class SubscriptionPlanAdminRepositoryTests
+{
+    private static SubscriptionPlanAdminRepository CreateRepo(ApplicationDbContext db) => new(db);
+
+    [Fact]
+    public async Task GetPlanDetailAsync_returns_null_when_missing()
+    {
+        using var fx = new TestDbFixture();
+        using var db = fx.CreateContext();
+        var repo = CreateRepo(db);
+        Assert.Null(await repo.GetPlanDetailAsync(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public async Task GetPlanDetailAsync_orders_periods_and_tiers()
+    {
+        using var fx = new TestDbFixture();
+        using var db = fx.CreateContext();
+        var planId = Guid.NewGuid();
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        db.SubscriptionPlans.Add(new SubscriptionPlan
+        {
+            Id = planId,
+            Name = "Zed",
+            Kind = SubscriptionPlanKind.PayPerBooking,
+            ChargeTimeAnchor = ChargeTimeAnchor.CreatedAtUtc,
+            Currency = "EUR",
+            IsActive = true
+        });
+        db.SubscriptionPlanPricingPeriods.Add(new SubscriptionPlanPricingPeriod
+        {
+            Id = p1,
+            SubscriptionPlanId = planId,
+            EffectiveFromUtc = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc)
+        });
+        db.SubscriptionPlanPricingPeriods.Add(new SubscriptionPlanPricingPeriod
+        {
+            Id = p2,
+            SubscriptionPlanId = planId,
+            EffectiveFromUtc = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            ChargePerBooking = 2m
+        });
+        db.SubscriptionPlanPricingTiers.Add(new SubscriptionPlanPricingTier
+        {
+            Id = Guid.NewGuid(),
+            SubscriptionPlanPricingPeriodId = p2,
+            Ordinal = 2,
+            InclusiveMaxBookingsInPeriod = 5,
+            ChargePerBooking = 1m
+        });
+        db.SubscriptionPlanPricingTiers.Add(new SubscriptionPlanPricingTier
+        {
+            Id = Guid.NewGuid(),
+            SubscriptionPlanPricingPeriodId = p2,
+            Ordinal = 1,
+            InclusiveMaxBookingsInPeriod = 3,
+            ChargePerBooking = 2m
+        });
+        await db.SaveChangesAsync();
+
+        var detail = await CreateRepo(db).GetPlanDetailAsync(planId);
+        Assert.NotNull(detail);
+        Assert.Equal(2, detail!.PricingPeriods.Count);
+        Assert.True(detail.PricingPeriods[0].EffectiveFromUtc > detail.PricingPeriods[1].EffectiveFromUtc);
+        Assert.Equal(2, detail.PricingPeriods[0].Tiers.Count);
+        Assert.Equal(1, detail.PricingPeriods[0].Tiers[0].Ordinal);
+    }
+
+    [Fact]
+    public async Task Create_Update_Delete_roundtrip_when_unused()
+    {
+        using var fx = new TestDbFixture();
+        using var db = fx.CreateContext();
+        var repo = CreateRepo(db);
+        var id = await repo.CreatePlanAsync(
+            "R1",
+            SubscriptionPlanKind.MonthlyBundle.ToString(),
+            ChargeTimeAnchor.FirstBillableAtUtc.ToString(),
+            null,
+            "SEK",
+            true,
+            default);
+        Assert.NotEqual(Guid.Empty, id);
+
+        var upd = await repo.UpdatePlanAsync(
+            id,
+            "R2",
+            SubscriptionPlanKind.Trial.ToString(),
+            ChargeTimeAnchor.CreatedAtUtc.ToString(),
+            3,
+            "nok",
+            false,
+            default);
+        Assert.True(upd.Success);
+
+        var badKind = await repo.UpdatePlanAsync(
+            id,
+            "R2",
+            "NotAKind",
+            ChargeTimeAnchor.CreatedAtUtc.ToString(),
+            3,
+            "NOK",
+            false,
+            default);
+        Assert.False(badKind.Success);
+
+        var badAnchor = await repo.UpdatePlanAsync(
+            id,
+            "R2",
+            SubscriptionPlanKind.Trial.ToString(),
+            "BadAnchor",
+            3,
+            "NOK",
+            false,
+            default);
+        Assert.False(badAnchor.Success);
+
+        var badTrial = await repo.UpdatePlanAsync(
+            id,
+            "R2",
+            SubscriptionPlanKind.Trial.ToString(),
+            ChargeTimeAnchor.CreatedAtUtc.ToString(),
+            null,
+            "NOK",
+            false,
+            default);
+        Assert.False(badTrial.Success);
+
+        var missing = await repo.UpdatePlanAsync(
+            Guid.NewGuid(),
+            "X",
+            SubscriptionPlanKind.PayPerBooking.ToString(),
+            ChargeTimeAnchor.CreatedAtUtc.ToString(),
+            null,
+            "EUR",
+            true,
+            default);
+        Assert.False(missing.Success);
+
+        var del = await repo.DeletePlanAsync(id, default);
+        Assert.True(del.Success);
+    }
+
+    [Fact]
+    public async Task DeletePlanAsync_blocked_when_company_assigned()
+    {
+        using var fx = new TestDbFixture();
+        using var db = fx.CreateContext();
+        var planId = Guid.NewGuid();
+        db.SubscriptionPlans.Add(new SubscriptionPlan
+        {
+            Id = planId,
+            Name = "P",
+            Kind = SubscriptionPlanKind.PayPerBooking,
+            ChargeTimeAnchor = ChargeTimeAnchor.CreatedAtUtc,
+            Currency = "EUR",
+            IsActive = true
+        });
+        db.Companies.Add(new CompanyEntity
+        {
+            Id = Guid.NewGuid(),
+            CompanyId = Guid.NewGuid().ToString("N"),
+            SubscriptionPlanId = planId
+        });
+        await db.SaveChangesAsync();
+
+        var r = await CreateRepo(db).DeletePlanAsync(planId, default);
+        Assert.False(r.Success);
+    }
+
+    [Fact]
+    public async Task DeletePlanAsync_blocked_when_billing_lines_reference_plan()
+    {
+        using var fx = new TestDbFixture();
+        using var db = fx.CreateContext();
+        var planId = Guid.NewGuid();
+        var periodPricingId = Guid.NewGuid();
+        var companyId = Guid.NewGuid();
+        db.SubscriptionPlans.Add(new SubscriptionPlan
+        {
+            Id = planId,
+            Name = "P",
+            Kind = SubscriptionPlanKind.PayPerBooking,
+            ChargeTimeAnchor = ChargeTimeAnchor.CreatedAtUtc,
+            Currency = "EUR",
+            IsActive = true
+        });
+        db.SubscriptionPlanPricingPeriods.Add(new SubscriptionPlanPricingPeriod
+        {
+            Id = periodPricingId,
+            SubscriptionPlanId = planId,
+            EffectiveFromUtc = DateTime.UtcNow
+        });
+        db.Companies.Add(new CompanyEntity { Id = companyId, CompanyId = Guid.NewGuid().ToString("N") });
+        var billingPeriodId = Guid.NewGuid();
+        db.CompanyBillingPeriods.Add(new CompanyBillingPeriod
+        {
+            Id = billingPeriodId,
+            CompanyId = companyId,
+            YearUtc = 2026,
+            MonthUtc = 1,
+            Currency = "EUR",
+            Status = CompanyBillingPeriodStatus.Open
+        });
+        db.BillingLineItems.Add(new BillingLineItem
+        {
+            Id = Guid.NewGuid(),
+            CompanyBillingPeriodId = billingPeriodId,
+            LineType = BillingLineType.PerBooking,
+            Amount = 1m,
+            Currency = "EUR",
+            SubscriptionPlanId = planId,
+            SubscriptionPlanPricingPeriodId = periodPricingId,
+            CreatedAtUtc = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+
+        var r = await CreateRepo(db).DeletePlanAsync(planId, default);
+        Assert.False(r.Success);
+    }
+
+    [Fact]
+    public async Task Pricing_periods_CRUD_and_tiers_replace()
+    {
+        using var fx = new TestDbFixture();
+        using var db = fx.CreateContext();
+        var repo = CreateRepo(db);
+        var planId = Guid.NewGuid();
+        db.SubscriptionPlans.Add(new SubscriptionPlan
+        {
+            Id = planId,
+            Name = "P",
+            Kind = SubscriptionPlanKind.TieredPayPerBooking,
+            ChargeTimeAnchor = ChargeTimeAnchor.CreatedAtUtc,
+            Currency = "EUR",
+            IsActive = true
+        });
+        await db.SaveChangesAsync();
+
+        var badAdd = await repo.AddPricingPeriodAsync(Guid.NewGuid(), DateTime.UtcNow, 1m, null, null, null, default);
+        Assert.False(badAdd.Success);
+
+        var add = await repo.AddPricingPeriodAsync(
+            planId,
+            new DateTime(2026, 3, 1, 12, 0, 0, DateTimeKind.Unspecified),
+            1.5m,
+            9m,
+            10,
+            2m,
+            default);
+        Assert.True(add.Success);
+
+        var periodId = (await db.SubscriptionPlanPricingPeriods.FirstAsync()).Id;
+
+        var upd = await repo.UpdatePricingPeriodAsync(periodId, DateTime.UtcNow, 2m, 8m, 11, 3m, default);
+        Assert.True(upd.Success);
+
+        var dupTiers = await repo.ReplaceTiersAsync(
+            periodId,
+            new[]
+            {
+                new AdminPricingTierInput { Ordinal = 1, ChargePerBooking = 1m },
+                new AdminPricingTierInput { Ordinal = 1, ChargePerBooking = 2m }
+            },
+            default);
+        Assert.False(dupTiers.Success);
+
+        var okTiers = await repo.ReplaceTiersAsync(
+            periodId,
+            new[]
+            {
+                new AdminPricingTierInput { Ordinal = 1, InclusiveMaxBookingsInPeriod = 5, ChargePerBooking = 1m },
+                new AdminPricingTierInput { Ordinal = 2, MonthlyFee = 4m }
+            },
+            default);
+        Assert.True(okTiers.Success);
+
+        var missingTier = await repo.ReplaceTiersAsync(Guid.NewGuid(), Array.Empty<AdminPricingTierInput>(), default);
+        Assert.False(missingTier.Success);
+
+        var delPeriodMissing = await repo.DeletePricingPeriodAsync(Guid.NewGuid(), default);
+        Assert.False(delPeriodMissing.Success);
+
+        var delOk = await repo.DeletePricingPeriodAsync(periodId, default);
+        Assert.True(delOk.Success);
+    }
+
+    [Fact]
+    public async Task DeletePricingPeriodAsync_blocked_when_referenced_by_line_item()
+    {
+        using var fx = new TestDbFixture();
+        using var db = fx.CreateContext();
+        var planId = Guid.NewGuid();
+        var periodPricingId = Guid.NewGuid();
+        var companyId = Guid.NewGuid();
+        db.SubscriptionPlans.Add(new SubscriptionPlan
+        {
+            Id = planId,
+            Name = "P",
+            Kind = SubscriptionPlanKind.PayPerBooking,
+            ChargeTimeAnchor = ChargeTimeAnchor.CreatedAtUtc,
+            Currency = "EUR",
+            IsActive = true
+        });
+        db.SubscriptionPlanPricingPeriods.Add(new SubscriptionPlanPricingPeriod
+        {
+            Id = periodPricingId,
+            SubscriptionPlanId = planId,
+            EffectiveFromUtc = DateTime.UtcNow
+        });
+        db.Companies.Add(new CompanyEntity { Id = companyId, CompanyId = Guid.NewGuid().ToString("N") });
+        var billingPeriodId = Guid.NewGuid();
+        db.CompanyBillingPeriods.Add(new CompanyBillingPeriod
+        {
+            Id = billingPeriodId,
+            CompanyId = companyId,
+            YearUtc = 2026,
+            MonthUtc = 2,
+            Currency = "EUR",
+            Status = CompanyBillingPeriodStatus.Open
+        });
+        db.BillingLineItems.Add(new BillingLineItem
+        {
+            Id = Guid.NewGuid(),
+            CompanyBillingPeriodId = billingPeriodId,
+            LineType = BillingLineType.PerBooking,
+            Amount = 1m,
+            Currency = "EUR",
+            SubscriptionPlanId = planId,
+            SubscriptionPlanPricingPeriodId = periodPricingId,
+            CreatedAtUtc = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+
+        var r = await CreateRepo(db).DeletePricingPeriodAsync(periodPricingId, default);
+        Assert.False(r.Success);
+    }
+
+    [Fact]
+    public async Task UpdatePricingPeriodAsync_NotFound()
+    {
+        using var fx = new TestDbFixture();
+        using var db = fx.CreateContext();
+        var r = await CreateRepo(db).UpdatePricingPeriodAsync(Guid.NewGuid(), DateTime.UtcNow, null, null, null, null, default);
+        Assert.False(r.Success);
+    }
+}

--- a/CargoHub.Tests/Billing/SubscriptionPlanSeedTests.cs
+++ b/CargoHub.Tests/Billing/SubscriptionPlanSeedTests.cs
@@ -1,5 +1,6 @@
 using CargoHub.Application.Billing;
 using CargoHub.Infrastructure.Billing;
+using CompanyEntity = CargoHub.Domain.Companies.Company;
 using CargoHub.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
@@ -17,5 +18,28 @@ public class SubscriptionPlanSeedTests
         await SubscriptionPlanSeed.EnsureDefaultTrialPlanAsync(ctx);
         var count = await ctx.SubscriptionPlans.CountAsync(p => p.Id == SubscriptionBillingConstants.DefaultTrialPlanId);
         Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task AssignDefaultTrialToCompaniesWithoutPlanAsync_SetsNullCompanies()
+    {
+        var fixture = new TestDbFixture();
+        using var ctx = fixture.CreateContext();
+        var companyId = Guid.NewGuid();
+        ctx.Companies.Add(new CompanyEntity
+        {
+            Id = companyId,
+            Name = "Legacy",
+            BusinessId = "LEG-1",
+            CompanyId = companyId.ToString("N"),
+            SubscriptionPlanId = null
+        });
+        await ctx.SaveChangesAsync();
+
+        await SubscriptionPlanSeed.EnsureDefaultTrialPlanAsync(ctx);
+        await SubscriptionPlanSeed.AssignDefaultTrialToCompaniesWithoutPlanAsync(ctx);
+
+        var updated = await ctx.Companies.AsNoTracking().SingleAsync(c => c.Id == companyId);
+        Assert.Equal(SubscriptionBillingConstants.DefaultTrialPlanId, updated.SubscriptionPlanId);
     }
 }

--- a/portal/src/app/[locale]/(protected)/manage/companies/page.tsx
+++ b/portal/src/app/[locale]/(protected)/manage/companies/page.tsx
@@ -11,6 +11,7 @@ import {
   adminPatchCompany,
   adminSendTestEmail,
   AdminCompanyLimitReductionRequiredError,
+  DEFAULT_TRIAL_SUBSCRIPTION_PLAN_ID,
   type AdminCompany,
   type AdminPatchCompanyBody,
   type AdminSubscriptionPlanSummary,
@@ -67,7 +68,8 @@ export default function ManageCompaniesPage() {
   const [editMaxUsers, setEditMaxUsers] = useState("");
   const [editMaxAdmins, setEditMaxAdmins] = useState("");
   const [editSubscriptionPlanId, setEditSubscriptionPlanId] = useState("");
-  const [editSubscriptionInitial, setEditSubscriptionInitial] = useState("");
+  /** Value from API when the edit dialog opened (`null` = company had no plan yet). */
+  const [editSubscriptionFromServer, setEditSubscriptionFromServer] = useState<string | null>(null);
   const [savingLimitsId, setSavingLimitsId] = useState<string | null>(null);
   const [savingSubscriptionId, setSavingSubscriptionId] = useState<string | null>(null);
   const [limitsError, setLimitsError] = useState<string | null>(null);
@@ -250,26 +252,27 @@ export default function ManageCompaniesPage() {
     setEditLimitsCompany(c);
     setEditMaxUsers(c.maxUserAccounts != null ? String(c.maxUserAccounts) : "");
     setEditMaxAdmins(c.maxAdminAccounts != null ? String(c.maxAdminAccounts) : "");
-    const sid = c.subscriptionPlanId ?? "";
-    setEditSubscriptionPlanId(sid);
-    setEditSubscriptionInitial(sid);
+    const raw = c.subscriptionPlanId?.trim() ?? "";
+    setEditSubscriptionFromServer(raw.length > 0 ? raw : null);
+    setEditSubscriptionPlanId(raw.length > 0 ? raw : DEFAULT_TRIAL_SUBSCRIPTION_PLAN_ID);
   };
 
   const handleSaveSubscriptionOnly = async () => {
     if (!token || !editLimitsCompany) return;
-    if (!editSubscriptionPlanId.trim()) {
+    const desired = editSubscriptionPlanId.trim();
+    if (!desired) {
       setLimitsError(tMc("subscriptionSelectRequired"));
       return;
     }
-    if (editSubscriptionPlanId === editSubscriptionInitial) {
+    if (editSubscriptionFromServer !== null && editSubscriptionFromServer === desired) {
       setLimitsError(null);
       return;
     }
     setSavingSubscriptionId(editLimitsCompany.id);
     setLimitsError(null);
     try {
-      await adminPatchCompany(token, editLimitsCompany.id, { subscriptionPlanId: editSubscriptionPlanId });
-      setEditSubscriptionInitial(editSubscriptionPlanId);
+      await adminPatchCompany(token, editLimitsCompany.id, { subscriptionPlanId: desired });
+      setEditSubscriptionFromServer(desired);
       refetchCompanies();
     } catch (e) {
       setLimitsError(e instanceof Error ? e.message : "Update failed");
@@ -297,11 +300,12 @@ export default function ManageCompaniesPage() {
       }
       body.maxAdminAccounts = p;
     }
+    const desiredSub = editSubscriptionPlanId.trim();
     if (
-      editSubscriptionPlanId.trim() &&
-      editSubscriptionPlanId !== editSubscriptionInitial
+      desiredSub &&
+      !(editSubscriptionFromServer !== null && editSubscriptionFromServer === desiredSub)
     ) {
-      body.subscriptionPlanId = editSubscriptionPlanId;
+      body.subscriptionPlanId = desiredSub;
     }
     if (Object.keys(body).length === 0) {
       setLimitsError("Change at least one limit, subscription, or cancel.");
@@ -311,7 +315,7 @@ export default function ManageCompaniesPage() {
     setLimitsError(null);
     try {
       await adminPatchCompany(token, editLimitsCompany.id, body);
-      if (body.subscriptionPlanId) setEditSubscriptionInitial(body.subscriptionPlanId);
+      if (body.subscriptionPlanId) setEditSubscriptionFromServer(body.subscriptionPlanId);
       setEditLimitsCompany(null);
       refetchCompanies();
     } catch (e) {
@@ -679,11 +683,9 @@ export default function ManageCompaniesPage() {
                   onChange={(e) => setEditSubscriptionPlanId(e.target.value)}
                   disabled={!!savingLimitsId || !!savingSubscriptionId}
                 >
-                  {editLimitsCompany?.subscriptionPlanId &&
-                    !subscriptionPlans.some((p) => p.id === editLimitsCompany.subscriptionPlanId) && (
-                      <option value={editLimitsCompany.subscriptionPlanId}>
-                        {planDisplayName(editLimitsCompany.subscriptionPlanId)}
-                      </option>
+                  {editSubscriptionPlanId &&
+                    !subscriptionPlans.some((p) => p.id === editSubscriptionPlanId) && (
+                      <option value={editSubscriptionPlanId}>{planDisplayName(editSubscriptionPlanId)}</option>
                     )}
                   {subscriptionPlans.map((p) => (
                     <option key={p.id} value={p.id}>

--- a/portal/src/lib/api.test.ts
+++ b/portal/src/lib/api.test.ts
@@ -15,8 +15,13 @@ import {
   getCourierContracts,
   putCourierContracts,
   adminGetCompanies,
+  adminCreateCompany,
   adminGetSubscriptionPlans,
+  adminPatchCompany,
+  adminSendTestEmail,
   adminGetCompanyBillingPeriods,
+  AdminCompanyLimitReductionRequiredError,
+  DEFAULT_TRIAL_SUBSCRIPTION_PLAN_ID,
   adminGetBillingPeriodDetail,
   adminGetUsers,
   adminPatchUser,
@@ -576,6 +581,93 @@ describe("api", () => {
       const list = await adminGetCompanies("token");
       expect(list[0].subscriptionPlanId).toBe("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1");
     });
+
+    it("returns empty list when response body is not an array", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [] }),
+      });
+      const list = await adminGetCompanies("token");
+      expect(list).toEqual([]);
+    });
+
+    it("normalizes PascalCase counts, invites, and empty subscription id", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            Id: "1",
+            CompanyId: "cid",
+            ActiveUserCount: 4,
+            AdminCount: 2,
+            InitialAdminInviteEmail: "adm@co.com",
+            InitialAdminInviteEmails: ["a1@co.com", "a2@co.com"],
+            SubscriptionPlanId: "",
+          },
+        ],
+      });
+      const list = await adminGetCompanies("token");
+      expect(list[0].activeUserCount).toBe(4);
+      expect(list[0].adminCount).toBe(2);
+      expect(list[0].initialAdminInviteEmail).toBe("adm@co.com");
+      expect(list[0].initialAdminInviteEmails).toEqual(["a1@co.com", "a2@co.com"]);
+      expect(list[0].subscriptionPlanId).toBeNull();
+    });
+  });
+
+  describe("adminCreateCompany", () => {
+    it("returns normalized company when API succeeds", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "new1",
+          name: "NewCo",
+          companyId: "nc",
+          businessId: "B-9",
+          subscriptionPlanId: DEFAULT_TRIAL_SUBSCRIPTION_PLAN_ID,
+        }),
+      });
+      const c = await adminCreateCompany("jwt", {
+        name: "NewCo",
+        businessId: "B-9",
+        subscriptionPlanId: DEFAULT_TRIAL_SUBSCRIPTION_PLAN_ID,
+      });
+      expect(c.id).toBe("new1");
+      expect(c.subscriptionPlanId).toBe(DEFAULT_TRIAL_SUBSCRIPTION_PLAN_ID);
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/companies"),
+        expect.objectContaining({ method: "POST" })
+      );
+    });
+
+    it("throws with message when API returns 400", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ message: "BusinessIdExists" }),
+      });
+      await expect(adminCreateCompany("jwt", { name: "X", businessId: "dup" })).rejects.toThrow("BusinessIdExists");
+    });
+
+    it("throws with status fallback when error body has no message", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        statusText: "Nope",
+        json: async () => ({}),
+      });
+      await expect(adminCreateCompany("jwt", { name: "X", businessId: "y" })).rejects.toThrow("Nope");
+    });
+
+    it("throws generic create failed when message and title are missing", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 418,
+        statusText: "",
+        json: async () => ({}),
+      });
+      await expect(adminCreateCompany("jwt", { name: "X", businessId: "y" })).rejects.toThrow(/Create failed \(418\)/);
+    });
   });
 
   describe("adminGetSubscriptionPlans", () => {
@@ -606,6 +698,157 @@ describe("api", () => {
         json: async () => ({ message: "Server error" }),
       });
       await expect(adminGetSubscriptionPlans("token")).rejects.toThrow(/Server error|500/);
+    });
+  });
+
+  describe("DEFAULT_TRIAL_SUBSCRIPTION_PLAN_ID", () => {
+    it("matches backend default trial plan id", () => {
+      expect(DEFAULT_TRIAL_SUBSCRIPTION_PLAN_ID).toBe("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1");
+    });
+  });
+
+  describe("adminPatchCompany", () => {
+    it("returns normalized company on success", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: "c1",
+          name: "Acme",
+          companyId: "x",
+          businessId: "B1",
+          subscriptionPlanId: DEFAULT_TRIAL_SUBSCRIPTION_PLAN_ID,
+        }),
+      });
+      const c = await adminPatchCompany("jwt", "c1", { subscriptionPlanId: DEFAULT_TRIAL_SUBSCRIPTION_PLAN_ID });
+      expect(c.id).toBe("c1");
+      expect(c.subscriptionPlanId).toBe(DEFAULT_TRIAL_SUBSCRIPTION_PLAN_ID);
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/companies/c1"),
+        expect.objectContaining({ method: "PATCH" })
+      );
+    });
+
+    it("throws AdminCompanyLimitReductionRequiredError on 409 LimitReductionRequired", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          errorCode: "LimitReductionRequired",
+          message: "Pick users",
+          activeUserCount: 5,
+          proposedMaxUserAccounts: 2,
+          adminCount: 2,
+          proposedMaxAdminAccounts: 1,
+          minimumUsersToDeactivate: 3,
+          minimumAdminsToDemote: 1,
+          businessId: "BIZ",
+        }),
+      });
+      await expect(adminPatchCompany("jwt", "c1", { maxUserAccounts: 2 })).rejects.toMatchObject({
+        name: "AdminCompanyLimitReductionRequiredError",
+        details: expect.objectContaining({
+          businessId: "BIZ",
+          minimumUsersToDeactivate: 3,
+          minimumAdminsToDemote: 1,
+        }),
+      });
+    });
+
+    it("throws AdminCompanyLimitReductionRequiredError with PascalCase conflict payload", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          ErrorCode: "LimitReductionRequired",
+          ActiveUserCount: 1,
+          MinimumUsersToDeactivate: 0,
+          MinimumAdminsToDemote: 0,
+          BusinessId: "X",
+        }),
+      });
+      try {
+        await adminPatchCompany("jwt", "c1", { maxAdminAccounts: 1 });
+        expect.fail("expected throw");
+      } catch (e) {
+        expect(e).toBeInstanceOf(AdminCompanyLimitReductionRequiredError);
+        expect((e as AdminCompanyLimitReductionRequiredError).details.activeUserCount).toBe(1);
+        expect((e as AdminCompanyLimitReductionRequiredError).details.businessId).toBe("X");
+      }
+    });
+
+    it("throws generic Error on 409 with other errorCode", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => ({ errorCode: "Conflict", message: "Other" }),
+      });
+      await expect(adminPatchCompany("jwt", "c1", {})).rejects.toThrow("Other");
+    });
+
+    it("uses title fallback when message missing on error", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ title: "Bad" }),
+      });
+      await expect(adminPatchCompany("jwt", "c1", {})).rejects.toThrow("Bad");
+    });
+
+    it("normalizes PascalCase fields on success", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          Id: "c9",
+          Name: "Pascal Co",
+          CompanyId: "cid9",
+          BusinessId: "B9",
+          SubscriptionPlanId: null,
+        }),
+      });
+      const c = await adminPatchCompany("jwt", "c9", { maxUserAccounts: 5 });
+      expect(c.id).toBe("c9");
+      expect(c.name).toBe("Pascal Co");
+      expect(c.subscriptionPlanId).toBeNull();
+    });
+  });
+
+  describe("adminSendTestEmail", () => {
+    it("returns payload when API succeeds", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, message: "sent" }),
+      });
+      const r = await adminSendTestEmail("jwt", "a@b.com");
+      expect(r.ok).toBe(true);
+      expect(r.message).toBe("sent");
+    });
+
+    it("throws with message when API fails", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ message: "SMTP down" }),
+      });
+      await expect(adminSendTestEmail("jwt", "a@b.com")).rejects.toThrow("SMTP down");
+    });
+
+    it("throws with title when message missing", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ title: "Unavailable" }),
+      });
+      await expect(adminSendTestEmail("jwt", "a@b.com")).rejects.toThrow("Unavailable");
+    });
+
+    it("throws generic test email failed when no message, title, or statusText", async () => {
+      (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        statusText: "",
+        json: async () => ({}),
+      });
+      await expect(adminSendTestEmail("jwt", "a@b.com")).rejects.toThrow(/Test email failed \(502\)/);
     });
   });
 

--- a/portal/src/lib/api.ts
+++ b/portal/src/lib/api.ts
@@ -403,6 +403,9 @@ export async function putBookingFieldRules(
 
 // --- Admin API (Super Admin only; pass JWT from auth) ---
 
+/** Matches backend `SubscriptionBillingConstants.DefaultTrialPlanId` (seeded "Trial" plan). */
+export const DEFAULT_TRIAL_SUBSCRIPTION_PLAN_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1';
+
 function normalizeAdminCompany(raw: Record<string, unknown>): AdminCompany {
   const ac = raw.activeUserCount ?? raw.ActiveUserCount;
   const ad = raw.adminCount ?? raw.AdminCount;


### PR DESCRIPTION
## Summary
- On API startup, companies with null \SubscriptionPlanId\ are assigned the seeded default **Trial** plan (after trial seed runs).
- \PATCH /admin/companies/{id}\ validates subscription plan id (non-empty GUID, plan exists).
- Portal **Manage companies**: preselects default trial when the company has no plan; save logic treats unassigned vs assigned correctly so Super Admin can persist trial or another plan.
- Exports \DEFAULT_TRIAL_SUBSCRIPTION_PLAN_ID\ from \pi.ts\ (matches backend constant).
- Tests: subscription backfill, handler errors, billing repository/invoice/MediatR tests, portal \pi.test\ additions for CI coverage gates (line & branch ≥ 75%).

## Merge
Please enable **auto-merge** (merge commit) after review; CI must pass.

Made with [Cursor](https://cursor.com)