### PR TITLE
fix(portal): dashboard bar charts visible on hover

### DIFF
--- a/portal/src/lib/dashboard-echarts.ts
+++ b/portal/src/lib/dashboard-echarts.ts
@@ -21,7 +21,8 @@ export function buildPeriodBarOption(
     grid: { left: 8, right: 8, top: 8, bottom: 8, containLabel: true },
     tooltip: {
       trigger: "axis",
-      axisPointer: { type: "shadow" },
+      // Shadow default z is above series and hides bars; keep highlight behind bars.
+      axisPointer: { type: "shadow", z: 0 },
       backgroundColor: theme.card,
       borderColor: theme.border,
       borderWidth: 1,
@@ -118,7 +119,7 @@ export function buildLast7DaysGroupedBarOption(
     },
     tooltip: {
       trigger: "axis",
-      axisPointer: { type: "shadow" },
+      axisPointer: { type: "shadow", z: 0 },
       backgroundColor: theme.card,
       borderColor: theme.border,
       borderWidth: 1,
@@ -241,7 +242,7 @@ export function buildCityBarOption(
     grid: { left: 4, right: 8, top: 4, bottom: 4, containLabel: true },
     tooltip: {
       trigger: "axis",
-      axisPointer: { type: "shadow" },
+      axisPointer: { type: "shadow", z: 0 },
       backgroundColor: theme.card,
       borderColor: theme.border,
       borderWidth: 1,


### PR DESCRIPTION
## Summary
Apache ECharts \xisPointer\ with \	ype: 'shadow'\ defaults to a z-index **above** bar series, so the grey column highlight covered the bars while the tooltip still showed correct values.

## Change
Set \z: 0\ on the shadow axis pointer in \uildPeriodBarOption\, \uildLast7DaysGroupedBarOption\, and \uildCityBarOption\ in \portal/src/lib/dashboard-echarts.ts\ so the highlight renders beneath the bars.

## Verification
- \
pm run build\ in \portal/\ succeeds.

## Release
After merge to \development\, promote via separate PRs: \development\ → \main\ and \development\ → \master\ per repo policy.