### PR TITLE
fix(portal): dashboard bar charts — line tooltip pointer

### DIFF
--- a/portal/src/lib/dashboard-echarts.test.ts
+++ b/portal/src/lib/dashboard-echarts.test.ts
@@ -30,6 +30,7 @@ describe("buildPeriodBarOption", () => {
     expect(data[0].itemStyle.color).toBe("#a00");
     expect(data[1].value).toBe(7);
     expect(opt.xAxis).toMatchObject({ type: "category", data: ["A", "B"] });
+    expect(opt.tooltip?.axisPointer).toMatchObject({ type: "line" });
   });
 });
 

--- a/portal/src/lib/dashboard-echarts.ts
+++ b/portal/src/lib/dashboard-echarts.ts
@@ -8,6 +8,21 @@ export type ThemeSlice = {
 };
 
 /**
+ * `shadow` axis pointers are drawn as a full-band rect; ECharts often stacks them above bar
+ * geometry, which hides bars on hover. A thin line shows the active category without covering bars.
+ */
+function barTooltipAxisPointer(theme: ThemeSlice) {
+  return {
+    type: "line" as const,
+    lineStyle: {
+      color: theme.border,
+      width: 1.5,
+      opacity: 0.65,
+    },
+  };
+}
+
+/**
  * Period comparison: vertical bars, one color per category.
  */
 export function buildPeriodBarOption(
@@ -21,8 +36,7 @@ export function buildPeriodBarOption(
     grid: { left: 8, right: 8, top: 8, bottom: 8, containLabel: true },
     tooltip: {
       trigger: "axis",
-      // Shadow default z is above series and hides bars; keep highlight behind bars.
-      axisPointer: { type: "shadow", z: 0 },
+      axisPointer: barTooltipAxisPointer(theme),
       backgroundColor: theme.card,
       borderColor: theme.border,
       borderWidth: 1,
@@ -119,7 +133,7 @@ export function buildLast7DaysGroupedBarOption(
     },
     tooltip: {
       trigger: "axis",
-      axisPointer: { type: "shadow", z: 0 },
+      axisPointer: barTooltipAxisPointer(theme),
       backgroundColor: theme.card,
       borderColor: theme.border,
       borderWidth: 1,
@@ -242,7 +256,7 @@ export function buildCityBarOption(
     grid: { left: 4, right: 8, top: 4, bottom: 4, containLabel: true },
     tooltip: {
       trigger: "axis",
-      axisPointer: { type: "shadow", z: 0 },
+      axisPointer: barTooltipAxisPointer(theme),
       backgroundColor: theme.card,
       borderColor: theme.border,
       borderWidth: 1,


### PR DESCRIPTION
## Problem
\xisPointer: { type: 'shadow' }\ paints a full-height band that ECharts often stacks **above** bar series, so bars disappear on hover (prior \z: 0\ was not reliable).

## Change
Use a **line** axis pointer (\arTooltipAxisPointer\) for period bars, last-7-days grouped bars, and horizontal city bars. Tooltip remains \	rigger: 'axis'\.

## Verification
- \
px vitest run src/lib/dashboard-echarts.test.ts\ — 7 passed
- \
pm run build\ in \portal/\ — OK
- Test asserts \	ooltip.axisPointer.type === 'line'\ for period chart.