### PR TITLE
fix(portal): chart hover blur, dropdown menus, themed popovers

### DIFF
--- a/portal/src/app/globals.css
+++ b/portal/src/app/globals.css
@@ -143,6 +143,8 @@
   --chart-3: oklch(0.5 0.1 160);
   --chart-4: oklch(0.55 0.15 300);
   --chart-5: oklch(0.5 0.18 30);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.18 0.01 264);
 }
 .dark[data-theme="minimalism"] {
   --background: oklch(0.14 0.01 264);
@@ -160,6 +162,8 @@
   --chart-3: oklch(0.65 0.1 160);
   --chart-4: oklch(0.6 0.15 300);
   --chart-5: oklch(0.55 0.18 30);
+  --popover: oklch(0.2 0.015 264);
+  --popover-foreground: oklch(0.95 0.005 264);
 }
 
 /* ========== SKEUOMORPHISM: warm wood/leather, realistic textures, heavy bevels ========== */
@@ -186,6 +190,8 @@
   --chart-3: oklch(0.45 0.1 45);
   --chart-4: oklch(0.6 0.1 85);
   --chart-5: oklch(0.5 0.12 35);
+  --popover: oklch(0.98 0.04 70);
+  --popover-foreground: oklch(0.28 0.06 55);
 }
 .dark[data-theme="skeuomorphism"] {
   --background: oklch(0.22 0.05 55);
@@ -207,6 +213,8 @@
   --chart-3: oklch(0.7 0.1 85);
   --chart-4: oklch(0.55 0.12 45);
   --chart-5: oklch(0.65 0.1 35);
+  --popover: oklch(0.28 0.06 55);
+  --popover-foreground: oklch(0.92 0.04 75);
 }
 [data-theme="skeuomorphism"] [data-slot="navbar"] {
   box-shadow:
@@ -227,7 +235,7 @@
     inset 0 -1px 0 rgb(0 0 0 / 0.08);
   background: linear-gradient(180deg, var(--card) 0%, color-mix(in oklch, var(--card) 90%, var(--muted) 10%) 100%);
   border: 1px solid color-mix(in oklch, var(--border) 70%, black 30%);
-  color: var(--card-foreground);
+  color: var(--popover-foreground);
 }
 [data-theme="skeuomorphism"] [data-slot="button"][data-variant="default"] {
   box-shadow:
@@ -272,6 +280,8 @@
   --chart-3: oklch(0.6 0.2 180);
   --chart-4: oklch(0.65 0.2 320);
   --chart-5: oklch(0.6 0.22 30);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.2 0.02 250);
 }
 .dark[data-theme="neobrutalism"] {
   --background: oklch(0.18 0.03 250);
@@ -291,6 +301,8 @@
   --chart-3: oklch(0.65 0.18 180);
   --chart-4: oklch(0.6 0.2 320);
   --chart-5: oklch(0.65 0.18 30);
+  --popover: oklch(0.24 0.04 250);
+  --popover-foreground: oklch(0.95 0.02 100);
 }
 [data-theme="neobrutalism"] [data-slot="navbar"] {
   border-width: 0 0 4px 0;
@@ -365,6 +377,8 @@
   --chart-3: oklch(0.55 0.18 320);
   --chart-4: oklch(0.65 0.15 140);
   --chart-5: oklch(0.6 0.18 30);
+  --popover: oklch(0.98 0.035 280);
+  --popover-foreground: oklch(0.28 0.06 280);
 }
 .dark[data-theme="claymorphism"] {
   --background: oklch(0.2 0.04 260);
@@ -384,6 +398,8 @@
   --chart-3: oklch(0.6 0.16 320);
   --chart-4: oklch(0.7 0.12 140);
   --chart-5: oklch(0.65 0.15 30);
+  --popover: oklch(0.26 0.05 270);
+  --popover-foreground: oklch(0.92 0.03 280);
 }
 [data-theme="claymorphism"] {
   --radius: 1.25rem;
@@ -408,11 +424,8 @@
     inset 0 2px 0 rgb(255 255 255 / 0.5),
     inset 0 -3px 0 rgb(0 0 0 / 0.08);
   background: linear-gradient(145deg, var(--card) 0%, color-mix(in oklch, var(--card) 60%, var(--muted) 40%) 100%);
-  color: var(--card-foreground);
-  border: 1px solid rgb(255 255 255 / 0.3);
-}
-[data-theme="claymorphism"] [data-slot="dropdown-menu-content"] {
   color: var(--popover-foreground);
+  border: 1px solid rgb(255 255 255 / 0.3);
 }
 [data-theme="claymorphism"] [data-slot="button"][data-variant="default"] {
   border-radius: 9999px;
@@ -469,5 +482,12 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+  /** Native `<select>` / form controls follow OS dark palette when `.dark` is set. */
+  html {
+    color-scheme: light;
+  }
+  html.dark {
+    color-scheme: dark;
   }
 }

--- a/portal/src/components/ui/dropdown-menu.tsx
+++ b/portal/src/components/ui/dropdown-menu.tsx
@@ -74,7 +74,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:data-[highlighted]:bg-destructive/10 data-[variant=destructive]:data-[highlighted]:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 dark:data-[variant=destructive]:data-[highlighted]:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
         className
       )}
       {...props}
@@ -92,7 +92,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       checked={checked}
@@ -128,7 +128,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -211,7 +211,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
         className
       )}
       {...props}

--- a/portal/src/lib/dashboard-echarts.test.ts
+++ b/portal/src/lib/dashboard-echarts.test.ts
@@ -23,8 +23,9 @@ describe("buildPeriodBarOption", () => {
       theme,
       "bookings",
     );
-    const series = opt.series?.[0];
+    const series = opt.series?.[0] as { type: string; emphasis?: { focus?: string } };
     expect(series?.type).toBe("bar");
+    expect(series?.emphasis?.focus).toBe("none");
     const data = series?.data as { value: number; itemStyle: { color: string } }[];
     expect(data[0].value).toBe(3);
     expect(data[0].itemStyle.color).toBe("#a00");

--- a/portal/src/lib/dashboard-echarts.ts
+++ b/portal/src/lib/dashboard-echarts.ts
@@ -23,6 +23,12 @@ function barTooltipAxisPointer(theme: ThemeSlice) {
 }
 
 /**
+ * Default axis emphasis uses `focus: 'self'`, which blurs other bars in the same grid and looks
+ * like a grey layer hiding columns. `focus: 'none'` keeps all bars visible while the tooltip shows.
+ */
+const barSeriesEmphasisNoBlur = { emphasis: { focus: "none" as const } };
+
+/**
  * Period comparison: vertical bars, one color per category.
  */
 export function buildPeriodBarOption(
@@ -60,6 +66,7 @@ export function buildPeriodBarOption(
       {
         type: "bar",
         name: bookingsLabel,
+        ...barSeriesEmphasisNoBlur,
         data: values.map((value, i) => ({
           value,
           itemStyle: { color: barColors[i % barColors.length], borderRadius: [14, 14, 0, 0] },
@@ -172,6 +179,7 @@ export function buildLast7DaysGroupedBarOption(
       {
         name: actualLabel,
         type: "bar",
+        ...barSeriesEmphasisNoBlur,
         data: counts.map((value) => ({
           value,
           itemStyle: { color: primaryBarColor, borderRadius: [12, 12, 0, 0] },
@@ -182,6 +190,7 @@ export function buildLast7DaysGroupedBarOption(
       {
         name: weekdayAvgLabel,
         type: "bar",
+        ...barSeriesEmphasisNoBlur,
         data: weekdayAverages.map((value) => ({
           value,
           itemStyle: { color: benchmarkBarColor, borderRadius: [12, 12, 0, 0] },
@@ -282,6 +291,7 @@ export function buildCityBarOption(
       {
         type: "bar",
         name: bookingsLabel,
+        ...barSeriesEmphasisNoBlur,
         data: counts.map((value) => ({
           value,
           itemStyle: { color: barColor, borderRadius: [0, 10, 10, 0] },
@@ -552,6 +562,7 @@ export function buildTodayVsAverageBulletOption(
     series: [
       {
         type: "bar",
+        ...barSeriesEmphasisNoBlur,
         data: [today],
         barWidth: 40,
         itemStyle: { color: "var(--chart-1)", borderRadius: [4, 4, 0, 0] },


### PR DESCRIPTION
## Charts
Disable ECharts bar **emphasis blur** (\emphasis: { focus: 'none' }\) so axis tooltips no longer grey out other columns (in addition to the existing line axis pointer).

## Dropdowns
- Radix menu items: \data-[highlighted]\ styles match \ocus:\ (pointer/keyboard).
- **globals.css:** \color-scheme\ on \html\ / \html.dark\ for native \<select>\ lists.
- **Design themes:** explicit \--popover\ / \--popover-foreground\ for minimalism, skeuomorphism, neobrutalism, claymorphism; skeu/clay menu surfaces use readable \popover-foreground\.

## Verification
\
px vitest run src/lib/dashboard-echarts.test.ts\ — pass.