### PR TITLE
Add contact footer to company admin invite emails

### DIFF
--- a/CargoHub.Api/appsettings.json
+++ b/CargoHub.Api/appsettings.json
@@ -17,7 +17,9 @@
   "Portal": {
     "PublicBaseUrl": "",
     "TourUrl": "",
-    "CompanyAdminFallbackEmailDomain": "example.com"
+    "CompanyAdminFallbackEmailDomain": "example.com",
+    "AdminInviteContactName": "Maleesha Kumarage",
+    "AdminInviteContactEmail": "contactmaleesha93@gmail.com"
   },
   "Branding": {
     "AppName": "CargoHub",

--- a/CargoHub.Infrastructure/Company/CompanyAdminInviteEmailHtml.cs
+++ b/CargoHub.Infrastructure/Company/CompanyAdminInviteEmailHtml.cs
@@ -1,0 +1,37 @@
+using CargoHub.Infrastructure.Options;
+
+namespace CargoHub.Infrastructure.Company;
+
+/// <summary>HTML fragments for company admin invite emails.</summary>
+public static class CompanyAdminInviteEmailHtml
+{
+    /// <summary>
+    /// Optional footer when <see cref="PortalPublicOptions.AdminInviteContactName"/> /
+    /// <see cref="PortalPublicOptions.AdminInviteContactEmail"/> are set in configuration.
+    /// </summary>
+    public static string BuildContactFooter(PortalPublicOptions portal)
+    {
+        var name = portal.AdminInviteContactName?.Trim();
+        var email = portal.AdminInviteContactEmail?.Trim();
+        if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(email))
+            return "";
+
+        if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(email))
+        {
+            return
+                "<p>For more information, you can contact " +
+                System.Net.WebUtility.HtmlEncode(name) +
+                " (<a href=\"mailto:" + System.Net.WebUtility.HtmlEncode(email) + "\">" +
+                System.Net.WebUtility.HtmlEncode(email) + "</a>).</p>";
+        }
+
+        if (!string.IsNullOrEmpty(email))
+        {
+            return "<p>For more information, contact <a href=\"mailto:" +
+                   System.Net.WebUtility.HtmlEncode(email) + "\">" +
+                   System.Net.WebUtility.HtmlEncode(email) + "</a>.</p>";
+        }
+
+        return "<p>For more information, you can contact " + System.Net.WebUtility.HtmlEncode(name) + ".</p>";
+    }
+}

--- a/CargoHub.Infrastructure/Company/CompanyAdminInviteIssuer.cs
+++ b/CargoHub.Infrastructure/Company/CompanyAdminInviteIssuer.cs
@@ -107,11 +107,13 @@ public sealed class CompanyAdminInviteIssuer : ICompanyAdminInviteIssuer
         var companyLabel = company?.Name ?? company?.BusinessId ?? companyId.ToString();
 
         var subject = $"Company admin invitation — {companyLabel}";
+        var contactFooter = CompanyAdminInviteEmailHtml.BuildContactFooter(_portal.Value);
         var body =
             $"<p>You have been invited as an administrator for <strong>{System.Net.WebUtility.HtmlEncode(companyLabel)}</strong>.</p>" +
             $"<p><a href=\"{System.Net.WebUtility.HtmlEncode(link)}\">Open the invitation</a> to choose your user name and password.</p>" +
             $"<p><a href=\"{System.Net.WebUtility.HtmlEncode(tourUrl)}\">Product tour</a> — overview of bookings, insight, and workflows (optional).</p>" +
-            "<p>If the link expires, ask a Super Admin to resend the invite.</p>";
+            "<p>If the link expires, ask a Super Admin to resend the invite.</p>" +
+            contactFooter;
 
         try
         {

--- a/CargoHub.Infrastructure/Options/PortalPublicOptions.cs
+++ b/CargoHub.Infrastructure/Options/PortalPublicOptions.cs
@@ -18,4 +18,10 @@ public sealed class PortalPublicOptions
 
     /// <summary>Domain for fallback admin invite when Super Admin does not set an email.</summary>
     public string CompanyAdminFallbackEmailDomain { get; set; } = "example.com";
+
+    /// <summary>Optional display name appended to admin invite emails as a contact line (with <see cref="AdminInviteContactEmail"/>).</summary>
+    public string AdminInviteContactName { get; set; } = "";
+
+    /// <summary>Optional email for the admin invite contact line (with <see cref="AdminInviteContactName"/>).</summary>
+    public string AdminInviteContactEmail { get; set; } = "";
 }

--- a/CargoHub.Tests/Company/CompanyAdminInviteEmailHtmlTests.cs
+++ b/CargoHub.Tests/Company/CompanyAdminInviteEmailHtmlTests.cs
@@ -1,0 +1,69 @@
+using CargoHub.Infrastructure.Company;
+using CargoHub.Infrastructure.Options;
+using Xunit;
+
+namespace CargoHub.Tests.Company;
+
+public class CompanyAdminInviteEmailHtmlTests
+{
+    [Fact]
+    public void BuildContactFooter_EmptyOptions_ReturnsEmpty()
+    {
+        var html = CompanyAdminInviteEmailHtml.BuildContactFooter(new PortalPublicOptions());
+        Assert.Equal("", html);
+    }
+
+    [Fact]
+    public void BuildContactFooter_NameAndEmail_ProducesParagraphWithMailto()
+    {
+        var html = CompanyAdminInviteEmailHtml.BuildContactFooter(new PortalPublicOptions
+        {
+            AdminInviteContactName = "Maleesha Kumarage",
+            AdminInviteContactEmail = "contactmaleesha93@gmail.com"
+        });
+
+        Assert.Contains("For more information, you can contact Maleesha Kumarage", html);
+        Assert.Contains("mailto:contactmaleesha93@gmail.com", html);
+        Assert.StartsWith("<p>", html);
+        Assert.EndsWith("</p>", html);
+    }
+
+    [Fact]
+    public void BuildContactFooter_EmailOnly_UsesShortWording()
+    {
+        var html = CompanyAdminInviteEmailHtml.BuildContactFooter(new PortalPublicOptions
+        {
+            AdminInviteContactName = "",
+            AdminInviteContactEmail = "only@example.com"
+        });
+
+        Assert.Contains("For more information, contact", html);
+        Assert.Contains("mailto:only@example.com", html);
+    }
+
+    [Fact]
+    public void BuildContactFooter_NameOnly_OmitsMailto()
+    {
+        var html = CompanyAdminInviteEmailHtml.BuildContactFooter(new PortalPublicOptions
+        {
+            AdminInviteContactName = "Support",
+            AdminInviteContactEmail = ""
+        });
+
+        Assert.Contains("you can contact Support", html);
+        Assert.DoesNotContain("mailto:", html);
+    }
+
+    [Fact]
+    public void BuildContactFooter_EncodesHtmlInName()
+    {
+        var html = CompanyAdminInviteEmailHtml.BuildContactFooter(new PortalPublicOptions
+        {
+            AdminInviteContactName = "A & B <script>",
+            AdminInviteContactEmail = "x@y.com"
+        });
+
+        Assert.Contains("A &amp; B &lt;script&gt;", html);
+        Assert.DoesNotContain("<script>", html);
+    }
+}


### PR DESCRIPTION
## Summary
Adds an optional **contact** paragraph to company admin invitation emails, driven by \Portal:AdminInviteContactName\ and \Portal:AdminInviteContactEmail\ in configuration.

## Details
- Encoded HTML footer with \mailto:\ link when both name and email are set
- Defaults in \ppsettings.json\ (override per environment via \Portal__*\ env vars if needed)
- Unit tests for \CompanyAdminInviteEmailHtml\

## Testing
- \dotnet test\ (CargoHub.Tests)
- \
pm run test\ / \
pm run test:coverage\ in \portal/\ (Vitest statement coverage ~96%)

Made with [Cursor](https://cursor.com)