### PR TITLE
fix(portal): design theme palette on rider navbar

### DIFF
--- a/portal/src/components/Navbar.test.tsx
+++ b/portal/src/components/Navbar.test.tsx
@@ -32,7 +32,15 @@ vi.mock("@/context/AuthContext", () => ({
 
 vi.mock("@/lib/api", () => ({
   getMe: vi.fn().mockResolvedValue({ roles: [] }),
-  DESIGN_THEMES: ["skeuomorphism", "neobrutalism", "claymorphism", "minimalism"],
+  DESIGN_THEMES: [
+    "skeuomorphism",
+    "neobrutalism",
+    "claymorphism",
+    "minimalism",
+    "glassmorphism",
+    "nord",
+    "synthwave",
+  ],
 }));
 
 vi.mock("@/context/BrandingContext", () => ({
@@ -116,5 +124,12 @@ describe("Navbar", () => {
     render(<Navbar />);
     const accountButton = screen.getByRole("button", { name: /Test User|account/i });
     expect(accountButton).toBeInTheDocument();
+  });
+
+  it("rider-only nav includes design theme control (palette)", () => {
+    mockRolesFromToken = ["Rider"];
+    render(<Navbar />);
+    expect(screen.getByTitle("label")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /riderDeliveries/i })).toBeInTheDocument();
   });
 });

--- a/portal/src/components/Navbar.tsx
+++ b/portal/src/components/Navbar.tsx
@@ -85,6 +85,24 @@ export function Navbar() {
             </Link>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" title={tDesignTheme("label")}>
+                  <Palette className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {DESIGN_THEMES.map((tKey) => (
+                  <DropdownMenuItem
+                    key={tKey}
+                    onClick={() => setTheme(tKey as DesignTheme)}
+                    className={theme === tKey ? "bg-accent" : undefined}
+                  >
+                    {tDesignTheme(tKey)}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="sm">
                   {locale.toUpperCase()}
                 </Button>


### PR DESCRIPTION
Rider-only users had no palette in the header, so design themes (including Glassmorphism, Nord, Synthwave) were never shown. Mirrors the main nav theme dropdown.

Made with [Cursor](https://cursor.com)